### PR TITLE
Add unit tests for activity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ project(extrachain-console LANGUAGES C CXX VERSION ${EXTRACHAIN_VERSION})
 set(EXTRACHAIN_STATIC_BUILD true)
 include(../extrachain-core/CMakeLists.txt)
 
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+FetchContent_MakeAvailable(googletest)
+
 set(EXTRACHAIN_CONSOLE_SOURCES
     headers/console/console_manager.h
     headers/console/push_manager.h
@@ -38,3 +45,6 @@ target_link_libraries(extrachain-console PRIVATE Qt6::Core Qt6::Network extracha
 set_property(TARGET extrachain-console PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+enable_testing()
+add_subdirectory(Units)

--- a/Units/CMakeLists.txt
+++ b/Units/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(testName UnitTests)
+
+add_executable(${testName}
+    main.cpp
+    TestActivityClient.cpp
+    TestActivityClient.h
+)
+
+
+target_include_directories(${testName} PUBLIC ${CMAKE_SOURCE_DIR})
+
+target_include_directories(${testName} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/headers ${EXTRACHAIN_CORE_INCLUDES})
+
+
+target_link_libraries(${testName}
+    gtest_main
+    Qt6::Core
+    Qt6::Network
+    extrachain
+)
+
+add_test(NAME ExampleTest COMMAND ExampleTest)

--- a/Units/TestActivityClient.cpp
+++ b/Units/TestActivityClient.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "TestActivityClient.h"
+
+TEST( activity_client, test1 ) {
+
+    ConnectionsManager manager("192.168.1.101", "8080", TestActorIndex::getInstance().getActorIndex()->firstId().toByteArray());
+
+    std::ifstream dbActivity(dbActPath);
+
+    EXPECT_EQ( true, dbActivity.good() );
+}
+
+
+TEST( activity_client, test2 ) {
+
+    ConnectionsManager manager("192.168.1.101", "8080", TestActorIndex::getInstance().getActorIndex()->firstId().toByteArray());
+
+    std::array<std::string, 4> collums{"hash", "timeactivity", "activity", "score"};
+
+    sqlite3* db;
+    sqlite3_stmt* stmt;
+
+    const std::string sql = "PRAGMA table_info(" + ActivityTableName + ");";
+
+    int rc = sqlite3_open(dbActPath.c_str(), &db);
+
+    EXPECT_EQ( 0, rc );
+
+    sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
+
+    int count = 0;
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        std::string columnName = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+        EXPECT_EQ( collums[count++], columnName );
+    }
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+TEST( activity_client, test3 ) {
+
+    int countConnect = 4;
+
+    ConnectionsManager manager("192.168.1.101", "8080", TestActorIndex::getInstance().getActorIndex()->firstId().toByteArray());
+
+    std::vector<Connection> client;
+    for(int i = 0; i < countConnect; ++i){
+        client.push_back(Connection{std::to_string(8000 + i), "192.168.1." + std::to_string(100 + i), static_cast<bool>(i&1) });
+    }
+
+    for(std::vector<Connection>::iterator it = client.begin(); it != client.end(); ++it){
+        manager.addActivity(*it);
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(4));
+
+    for(std::vector<Connection>::iterator it = client.begin() + 1; it != client.end(); ++it){
+        manager.removeActivity(*it);
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+    }
+
+    std::unordered_map<std::string, uint64_t> score;
+    for(std::vector<Connection>::iterator it = client.begin(); it != client.end(); ++it){
+        score.insert(std::pair(it->address, manager.getActivityScore(*it)));
+    }
+
+    manager.synchroActivityDB();
+    manager.loadActivityRecords();
+
+    int i = 0;
+    for(std::vector<Connection>::iterator it = client.begin(); it != client.end(); ++it){
+        EXPECT_EQ(score.at(it->address), manager.getActivityScore(*it));
+    }
+}

--- a/Units/TestActivityClient.h
+++ b/Units/TestActivityClient.h
@@ -1,0 +1,46 @@
+#ifndef TESTACTIVITYCLIENT_H
+#define TESTACTIVITYCLIENT_H
+
+#include "managers/connections_manager.h"
+#include "datastorage/index/actorindex.h"
+#include <sqlite3.h>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+class TestActorIndex {
+
+    ActorIndex *actorIndex;
+
+    TestActorIndex(){
+        ExtraChainNode node;
+        actorIndex = new ActorIndex(node);
+    }
+
+    ~TestActorIndex(){
+        delete actorIndex;
+    }
+
+    TestActorIndex(const TestActorIndex&) = delete;
+    TestActorIndex& operator=(const TestActorIndex&) = delete;
+
+
+
+public:
+    static TestActorIndex& getInstance() {
+        std::filesystem::path filePath = dbActPath;
+        if (fs::exists(filePath))
+            fs::remove(filePath);
+        static TestActorIndex instance;
+        return instance;
+    }
+
+
+    ActorIndex* getActorIndex() const {
+        return actorIndex;
+    }
+
+};
+
+
+#endif // TESTACTIVITYCLIENT_H

--- a/Units/main.cpp
+++ b/Units/main.cpp
@@ -1,0 +1,7 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/sources/console/console_manager.cpp
+++ b/sources/console/console_manager.cpp
@@ -113,7 +113,7 @@ void ConsoleManager::commandReceiver(QString command) {
             qDebug() << "sendtx" << toId << toAmount;
 
             ActorId receiver(toId.toStdString());
-            BigNumber amount = Transaction::visibleToAmount(toAmount);
+            BigNumberFloat amount = Transaction::visibleToAmount(toAmount.toStdString());
 
             if (mainActorId != firstId)
                 node->createTransaction(receiver, amount, ActorId());


### PR DESCRIPTION
The code is going to add new functionality to calculate and save in a SQLite table a new work coefficient for computers in the network. We calculate the new coefficient according to the following rules:

    If a computer is working in the network, it will gain one score every second.
    If a computer isn't working in the network, it will lose one score every second.