### PR TITLE
Fix high CPU usage in Console input handling on Windows

### DIFF
--- a/sources/console/console_manager.cpp
+++ b/sources/console/console_manager.cpp
@@ -307,6 +307,15 @@ void ConsoleManager::startInput() {
         return;
     }
 
+    #ifdef Q_OS_WINDOWS
+    DWORD consoleMode;
+    bool isInteractive = GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode);
+    if (!isInteractive) {
+        qDebug() << "[Console] Console is not interactive, command input is disabled";
+        return;
+    }
+    #endif
+
     connect(&consoleInput, &ConsoleInput::input, this, &ConsoleManager::commandReceiver);
     ThreadPool::addThread(&consoleInput);
 #elif defined(Q_OS_UNIX)


### PR DESCRIPTION
## Problem
When running the application in a non-interactive console environment on Windows (e.g., through Qt Creator), the console input handling code was causing high CPU usage due to constant polling.

## Solution
This PR modifies the console input handling to detect whether the console is in interactive mode. If it's not interactive (such as when run in Qt Creator), it disables command input, preventing the high CPU usage.

## Changes
- Added a check using `GetConsoleMode()` to determine if the console is interactive.
- If the console is not interactive, the command input is disabled and a debug message is logged.

## Testing
- Tested the application running in Qt Creator to ensure CPU usage remains low.
- Verified that the application still functions correctly in a normal Windows command prompt.

## Additional Notes
This fix specifically targets Windows environments where console input might not be available, improving performance and reducing resource usage in development environments like Qt Creator.