### PR TITLE
[API] Add WebAssembly contract endpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ add_executable(extrachain-console
         ${EXTRACHAIN_CONSOLE_SOURCES}
 )
 
-add_compile_definitions(RUN_API="${RUN_API}")
 target_include_directories(extrachain-console PUBLIC ${CMAKE_CURRENT_LIST_DIR}/headers ${EXTRACHAIN_CORE_INCLUDES})
 
 # git
@@ -43,7 +42,11 @@ execute_process(COMMAND git --git-dir ${CMAKE_CURRENT_LIST_DIR}/.git --work-tree
 execute_process(COMMAND git --git-dir ${CMAKE_CURRENT_LIST_DIR}/.git --work-tree $$PWD symbolic-ref --short HEAD OUTPUT_VARIABLE GIT_BRANCH)
 string(STRIP "${GIT_COMMIT}" GIT_COMMIT)
 string(STRIP "${GIT_BRANCH}" GIT_BRANCH)
-add_compile_definitions(GIT_COMMIT="${GIT_COMMIT}" GIT_BRANCH="${GIT_BRANCH}")
+target_compile_definitions(extrachain-console PRIVATE
+        RUN_API="${RUN_API}"
+        GIT_COMMIT="${GIT_COMMIT}"
+        GIT_BRANCH="${GIT_BRANCH}"
+)
 
 target_link_libraries(extrachain-console PRIVATE Qt6::Core Qt6::Network extrachain Crow::Crow asio::asio)
 
@@ -52,6 +55,7 @@ if(UNIX AND NOT APPLE) # LINUX
 endif()
 
 if(WIN32)
+    target_compile_definitions(extrachain-console PRIVATE _WIN32_WINNT=0x0A00)
     target_link_libraries(extrachain-console PRIVATE dbghelp)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.20)
 project(extrachain-console LANGUAGES C CXX VERSION 1.0)
 
 set(EXTRACHAIN_STATIC_BUILD true)
-include(../extrachain-core/CMakeLists.txt)
+set(EXTRACHAIN_CORE_DIR "${CMAKE_CURRENT_LIST_DIR}/../extrachain-core" CACHE PATH "ExtraChain Core source directory")
+include(${EXTRACHAIN_CORE_DIR}/CMakeLists.txt)
 set(RUN_API TRUE)
 
 # include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_compile_definitions(extrachain-console PRIVATE
         GIT_BRANCH="${GIT_BRANCH}"
 )
 
-target_link_libraries(extrachain-console PRIVATE Qt6::Core Qt6::Network extrachain Crow::Crow asio::asio)
+target_link_libraries(extrachain-console PRIVATE Qt6::Core Qt6::Network Qt6::WebSockets extrachain Crow::Crow asio::asio)
 
 if(UNIX AND NOT APPLE) # LINUX
     target_link_libraries(extrachain-console PRIVATE stdc++exp backtrace)
@@ -57,6 +57,18 @@ endif()
 if(WIN32)
     target_compile_definitions(extrachain-console PRIVATE _WIN32_WINNT=0x0A00)
     target_link_libraries(extrachain-console PRIVATE dbghelp)
+
+    get_target_property(QT_QMAKE_EXECUTABLE Qt6::qmake IMPORTED_LOCATION)
+    get_filename_component(QT_BINARY_DIRECTORY "${QT_QMAKE_EXECUTABLE}" DIRECTORY)
+    find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${QT_BINARY_DIRECTORY}" REQUIRED)
+    add_custom_command(TARGET extrachain-console POST_BUILD
+        COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+            --no-compiler-runtime
+            --no-translations
+            "$<TARGET_FILE:extrachain-console>"
+        COMMENT "Deploying the Qt runtime"
+        VERBATIM
+    )
 endif()
 
 set_property(TARGET extrachain-console PROPERTY POSITION_INDEPENDENT_CODE 1)

--- a/docs/EXTRACHAIN_API.md
+++ b/docs/EXTRACHAIN_API.md
@@ -5,6 +5,16 @@ REST API for interacting with the ExtraChain node.
 **Base URL:** `http://<host>:17581`  
 **Authentication:** All endpoints require an `token` parameter (POST body or query string).
 
+Contract endpoints use MessagePack arguments encoded as URL-safe Base64. State-changing calls return `202` with a transaction hash. Read-only queries return the contract result without creating a transaction.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/contract/deploy` | Deploy a WebAssembly contract |
+| `POST` | `/contract/call` | Submit a state-changing contract method |
+| `POST` | `/contract/query` | Run a read-only contract method |
+| `GET` | `/contract/inspect` | Read the active version and state hashes |
+| `POST` | `/contract/upgrade` | Submit an owner-approved immutable module upgrade |
+
 To start the API, pass `--api-token` on launch:
 ```bash
 ./extrachain-console --api-token <your_token>

--- a/docs/EXTRACHAIN_API.md
+++ b/docs/EXTRACHAIN_API.md
@@ -5,7 +5,13 @@ REST API for interacting with the ExtraChain node.
 **Base URL:** `http://<host>:17581`  
 **Authentication:** All endpoints require an `token` parameter (POST body or query string).
 
-Contract endpoints use MessagePack arguments encoded as URL-safe Base64. State-changing calls return `202` with a transaction hash. Read-only queries return the contract result without creating a transaction.
+Contract endpoints accept an `arguments` JSON value or MessagePack bytes in the URL-safe Base64
+`arguments_base64` field. State-changing calls return `202` with a transaction hash. Read-only
+queries return the contract result without creating a transaction.
+
+Contract calls use transaction schema `2`. Each call records the previous and result state hash.
+Deploy, upgrade, and every 256th state change publish an ExDFS checkpoint. Other calls update one
+local atomic state head and do not create a state file or manifest.
 
 | Method | Path | Purpose |
 |---|---|---|

--- a/headers/console/console_api.h
+++ b/headers/console/console_api.h
@@ -20,8 +20,9 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 class ExtraChainNode;
 
 long long parseTimeToMs(const std::string& time_str);
-void      run_api(ExtraChainNode* node, const std::string& api_token);
+void      run_api(ExtraChainNode* node, const std::string& api_token, std::uint16_t port = 17581);

--- a/main.cpp
+++ b/main.cpp
@@ -21,13 +21,17 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QElapsedTimer>
+#include <QFile>
 #include <QLockFile>
 #include <QStandardPaths>
 
 #include <csignal>
 
 #include "dfs/dfs_controller.h"
+#include "contracts/contract_codec.h"
+#include "contracts/toolchain_registry.h"
 #include "extrachain_version.h"
+#include "managers/token_manager.h"
 #include "managers/thoth_manager.h"
 #include "utils/exc_utils.h"
 #include "console/console_manager.h"
@@ -50,6 +54,181 @@
 #ifndef EXTRACHAIN_CMAKE
     #include "preconfig.h"
 #endif
+
+namespace {
+    struct OneShotOptions {
+        QString operation;
+        QString contract_id;
+        QString kind;
+        QString method;
+        QString arguments = "{}";
+        QString module;
+        QString token_name;
+        QString token_ticker;
+        QString token_supply;
+        int     token_decimals = 8;
+        QString project_name;
+        QString source;
+    };
+
+    std::expected<std::vector<std::uint8_t>, std::string> arguments(const QString& value) {
+        auto encoded =
+            ExtraChain::Contracts::Codec::encode_json(value.trimmed().isEmpty() ? "{}" : value.toStdString());
+        if (!encoded.has_value()) {
+            return std::unexpected(encoded.error().detail);
+        }
+        return *encoded;
+    }
+
+    std::expected<std::vector<std::uint8_t>, std::string> module_bytes(const QString& path) {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly) || file.size() <= 0) {
+            return std::unexpected("Cannot read the WebAssembly module");
+        }
+        const auto data = file.readAll();
+        return std::vector<std::uint8_t>(data.begin(), data.end());
+    }
+
+    int run_one_shot(ExtraChainNode* node, const OneShotOptions& options) {
+        if (options.operation.isEmpty()) {
+            return -1;
+        }
+        const auto fail = [](const std::string& message) {
+            fmt::println(stderr, "{{\"error\":{}}}", boost::json::serialize(message));
+            return 2;
+        };
+        if (options.operation == "contract-list") {
+            fmt::println("{}", Json::serialize(node->list_contracts()));
+            return 0;
+        }
+        if (options.operation == "toolchain-status") {
+            const auto result = node->toolchain_registry()->manifest();
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            fmt::println("{}", Json::serialize(*result));
+            return 0;
+        }
+        if (options.operation == "toolchain-enable" || options.operation == "toolchain-update") {
+            const auto root =
+                QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+            ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+            const auto result = installer.install_stable(options.operation == "toolchain-enable");
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            fmt::println("{}", Json::serialize(result->manifest));
+            return 0;
+        }
+        if (options.operation == "contract-build") {
+            QFile source(options.source);
+            if (!source.open(QIODevice::ReadOnly)) {
+                return fail("Cannot read the Rust source file");
+            }
+            const auto root =
+                QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+            ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+            const auto                                result =
+                installer.build_contract(QString::fromUtf8(source.readAll()), options.project_name);
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            boost::json::object response;
+            response["module"] = result->toStdString();
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+        if (options.operation == "token-create") {
+            const auto wallet = node->account_controller()->current_wallet();
+            if (wallet.empty()) {
+                return fail("A current wallet is required");
+            }
+            if (options.token_name.isEmpty() || options.token_ticker.isEmpty() || options.token_supply.isEmpty()
+                || options.token_decimals < 0 || options.token_decimals > 18) {
+                return fail("Token fields are invalid");
+            }
+            const auto result =
+                node->token_manager()->create_token(wallet.id(),
+                                                    options.token_name.toStdString(),
+                                                    options.token_ticker.toUpper().toStdString(),
+                                                    BigNumberFloat(options.token_supply.toStdString()),
+                                                    "#FA5448",
+                                                    {},
+                                                    static_cast<std::uint8_t>(options.token_decimals));
+            if (!result.has_value()) {
+                return fail("Core rejected the token request");
+            }
+            boost::json::object response;
+            response["token_id"] = result->token_id.to_string();
+            response["owner_id"] = result->owner_id.to_string();
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+
+        const auto input = arguments(options.arguments);
+        if (!input.has_value()) {
+            return fail(input.error());
+        }
+        if (options.operation == "contract-deploy") {
+            const auto module = module_bytes(options.module);
+            if (!module.has_value()) {
+                return fail(module.error());
+            }
+            const auto result = node->submit_contract_deploy(options.kind.toStdString(), *module, *input);
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            boost::json::object response;
+            response["contract_id"]      = result->receiver().to_string();
+            response["transaction_hash"] = result->hash();
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+        const auto contract_id = ActorId::create(options.contract_id.toStdString());
+        if (!contract_id.has_value()) {
+            return fail("Contract ID is invalid");
+        }
+        if (options.operation == "contract-call") {
+            const auto result = node->submit_contract_call(*contract_id, options.method.toStdString(), *input);
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            boost::json::object response;
+            response["transaction_hash"] = result->hash();
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+        if (options.operation == "contract-query") {
+            const auto result = node->query_contract(*contract_id, options.method.toStdString(), *input);
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            boost::json::object response;
+            response["data_base64"] = Utils::to_base64(result->data);
+            if (const auto json = ExtraChain::Contracts::Codec::decode_json(result->data); json.has_value()) {
+                response["data"] = boost::json::parse(*json);
+            }
+            response["state_hash"] = result->state_hash;
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+        if (options.operation == "contract-upgrade") {
+            const auto module = module_bytes(options.module);
+            if (!module.has_value()) {
+                return fail(module.error());
+            }
+            const auto result = node->submit_contract_upgrade(*contract_id, *module, *input);
+            if (!result.has_value()) {
+                return fail(result.error().detail);
+            }
+            boost::json::object response;
+            response["transaction_hash"] = result->hash();
+            fmt::println("{}", boost::json::serialize(response));
+            return 0;
+        }
+        return fail("Unknown operation");
+    }
+} // namespace
 
 #ifdef Q_OS_WIN
 const char* strsignal(int sig) {
@@ -222,17 +401,31 @@ int main(int argc, char* argv[]) {
     QCommandLineOption fileIdOption("create-fileid-template", "Create FileId template");
     QCommandLineOption channelsVectorOption("create-channels-vector", "Create channels vector");
     QCommandLineOption tokenAllocationsOption("create-token-allocations",
-                                             "Create token allocations dictionary for minting freeze");
-    QCommandLineOption backfillTokenAllocationsOption("backfill-token-allocations",
-                                                     "Backfill token allocations from chain (April 1 2026 to now)");
+                                              "Create token allocations dictionary for minting freeze");
+    QCommandLineOption
+                       backfillTokenAllocationsOption("backfill-token-allocations",
+                                       "Backfill token allocations from chain (April 1 2026 to now)");
     QCommandLineOption megaImportOption("import-from-mega", "Import from console-data/0 file");
     QCommandLineOption clearBalance("clear-balance", "Clear txs with balance < 0");
     QCommandLineOption dagMode("dag-mode", "Choose dag mode: full / light", "mode");
     QCommandLineOption dfsMode("dfs-mode", "Choose dfs mode: full / light", "mode");
     QCommandLineOption regenControls("regen-controls", "Regerarate controls");
     QCommandLineOption apiTokenOption("api-token", "API token (required to start REST API)", "api-token");
-    QCommandLineOption createMintSubsOption("create-mint-subs",
-                                            "Register mint actor in profile and create SubscriptionsPay dictionary");
+    QCommandLineOption
+                       createMintSubsOption("create-mint-subs",
+                             "Register mint actor in profile and create SubscriptionsPay dictionary");
+    QCommandLineOption operationOption("operation", "Run one operation and exit", "operation");
+    QCommandLineOption contractIdOption("contract-id", "Contract ID", "contract-id");
+    QCommandLineOption contractKindOption("contract-kind", "Contract kind", "kind");
+    QCommandLineOption contractMethodOption("contract-method", "Contract method", "method");
+    QCommandLineOption contractArgumentsOption("contract-arguments", "Contract JSON arguments", "json", "{}");
+    QCommandLineOption contractModuleOption("contract-module", "WebAssembly module path", "path");
+    QCommandLineOption tokenNameOption("token-name", "Token name", "name");
+    QCommandLineOption tokenTickerOption("token-ticker", "Token ticker", "ticker");
+    QCommandLineOption tokenSupplyOption("token-supply", "Initial token supply", "amount");
+    QCommandLineOption tokenDecimalsOption("token-decimals", "Token decimal precision", "decimals", "8");
+    QCommandLineOption projectNameOption("project-name", "Rust contract project name", "name");
+    QCommandLineOption sourceOption("source", "Rust contract source file", "path");
 
     parser.addOptions({ debugLogsOption,
                         dirOption,
@@ -263,8 +456,39 @@ int main(int argc, char* argv[]) {
                         tokenAllocationsOption,
                         backfillTokenAllocationsOption,
                         apiTokenOption,
-                        createMintSubsOption });
+                        createMintSubsOption,
+                        operationOption,
+                        contractIdOption,
+                        contractKindOption,
+                        contractMethodOption,
+                        contractArgumentsOption,
+                        contractModuleOption,
+                        tokenNameOption,
+                        tokenTickerOption,
+                        tokenSupplyOption,
+                        tokenDecimalsOption,
+                        projectNameOption,
+                        sourceOption });
     parser.process(app);
+
+    bool           decimals_ok = false;
+    OneShotOptions one_shot {
+        .operation      = parser.value(operationOption).trimmed(),
+        .contract_id    = parser.value(contractIdOption).trimmed(),
+        .kind           = parser.value(contractKindOption).trimmed(),
+        .method         = parser.value(contractMethodOption).trimmed(),
+        .arguments      = parser.value(contractArgumentsOption),
+        .module         = parser.value(contractModuleOption),
+        .token_name     = parser.value(tokenNameOption).trimmed(),
+        .token_ticker   = parser.value(tokenTickerOption).trimmed(),
+        .token_supply   = parser.value(tokenSupplyOption).trimmed(),
+        .token_decimals = parser.value(tokenDecimalsOption).toInt(&decimals_ok),
+        .project_name   = parser.value(projectNameOption).trimmed(),
+        .source         = parser.value(sourceOption),
+    };
+    if (!decimals_ok) {
+        one_shot.token_decimals = -1;
+    }
 
     // TODO: allow absolute directory
     QString dirName = Utils::fix_file_name(parser.value(dirOption), "");
@@ -294,7 +518,7 @@ int main(int argc, char* argv[]) {
 
     bool debug_logs = parser.isSet(debugLogsOption);
 #ifdef QT_DEBUG
-    debug_logs = !parser.isSet(debugLogsOption);
+    debug_logs            = !parser.isSet(debugLogsOption);
     Network::networkDebug = parser.isSet(netdebOption);
     eInfo("Debug logs enabled: {}", debug_logs);
 #endif
@@ -387,13 +611,20 @@ int main(int argc, char* argv[]) {
         QString importFile = parser.value(importOption);
         if (!importFile.isEmpty()) {
             QFile file(importFile);
-            file.open(QFile::ReadOnly);
+            if (!file.open(QFile::ReadOnly)) {
+                eInfo("Can't open import file: {}", file.errorString());
+                std::exit(1);
+            }
             auto data = file.readAll().toStdString();
             if (data.empty()) {
                 eInfo("Incorrect import");
-                std::exit(0);
+                std::exit(1);
             }
-            node->import_profile(data, login.toStdString(), password.toStdString());
+            const auto imported = node->import_profile(data, login.toStdString(), password.toStdString());
+            if (!imported.has_value()) {
+                eInfo("Can't import profile: {}", Utils::enum_value_name_value(imported.error()));
+                std::exit(1);
+            }
             file.close();
         }
 
@@ -417,6 +648,12 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        const auto one_shot_exit = run_one_shot(node, one_shot);
+        if (one_shot_exit >= 0) {
+            QCoreApplication::exit(one_shot_exit);
+            return;
+        }
+
         if (parser.isSet(dagGenesisOption)) {
             node->create_new_dag();
         }
@@ -436,7 +673,6 @@ int main(int argc, char* argv[]) {
             } else {
                 eInfo("Can't create tokens cache vector");
             }
-
         }
 
         bool is_username = parser.isSet(usernamesOption);
@@ -569,15 +805,17 @@ int main(int argc, char* argv[]) {
                         eInfo("[create-mint-subs] mint actor {} already in profile", mint_actor.id());
                     }
 
-                    auto sub_search = Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(
-                        node->dfs()->get_db_instance(), mint_actor.id(),
-                        Dfs::Basic::TEMPLATE_DICTIONARY, "SubscriptionsPay");
+                    auto sub_search = Dfs::Tables::DirsFile::ActorSpace::
+                        search_file_by_folder_and_name(node->dfs()->get_db_instance(),
+                                                       mint_actor.id(),
+                                                       Dfs::Basic::TEMPLATE_DICTIONARY,
+                                                       "SubscriptionsPay");
                     if (sub_search.has_value()) {
                         eInfo("[create-mint-subs] SubscriptionsPay dictionary already exists: {}",
                               sub_search->file_id);
                     } else {
-                        auto dict_res = node->dfs()->store_dictionary(mint_actor.id(), mint_actor.id(),
-                                                                      "SubscriptionsPay");
+                        auto dict_res =
+                            node->dfs()->store_dictionary(mint_actor.id(), mint_actor.id(), "SubscriptionsPay");
                         if (!dict_res.has_value()) {
                             eCritical("[create-mint-subs] can't create SubscriptionsPay dictionary: {}",
                                       Utils::enum_value_name_value(dict_res.error()));

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,7 @@
 #include "extrachain_version.h"
 #include "managers/token_manager.h"
 #include "managers/thoth_manager.h"
+#include "network/network_manager.h"
 #include "utils/exc_utils.h"
 #include "console/console_manager.h"
 #include "managers/extrachain_node.h"
@@ -385,6 +386,7 @@ int main(int argc, char* argv[]) {
     QCommandLineOption passOption("password", "Set password", "password");
     QCommandLineOption inputOption("disable-input", "Console input disable");
     QCommandLineOption core("core", "First network creation");
+    QCommandLineOption joinOption("join", "Create a local user profile and join an existing network");
     QCommandLineOption dagGenesisOption("dag-genesis", "First dag creation");
     QCommandLineOption importOption("import", "Import from file", "import");
     QCommandLineOption netdebOption("network-debug", "Print all messages. Only for debug build");
@@ -411,7 +413,9 @@ int main(int argc, char* argv[]) {
     QCommandLineOption dfsMode("dfs-mode", "Choose dfs mode: full / light", "mode");
     QCommandLineOption regenControls("regen-controls", "Regerarate controls");
     QCommandLineOption apiTokenOption("api-token", "API token (required to start REST API)", "api-token");
+    QCommandLineOption apiPortOption("api-port", "REST API listen port", "port", "17581");
     QCommandLineOption networkPortOption("network-port", "WebSocket listen port", "port", "17593");
+    QCommandLineOption peerOption("peer", "Connect to a WebSocket peer as host:port", "host:port");
     QCommandLineOption
                        createMintSubsOption("create-mint-subs",
                              "Register mint actor in profile and create SubscriptionsPay dictionary");
@@ -434,6 +438,7 @@ int main(int argc, char* argv[]) {
                         passOption,
                         inputOption,
                         core,
+                        joinOption,
                         dagGenesisOption,
                         clearDataOption,
                         importOption,
@@ -457,7 +462,9 @@ int main(int argc, char* argv[]) {
                         tokenAllocationsOption,
                         backfillTokenAllocationsOption,
                         apiTokenOption,
+                        apiPortOption,
                         networkPortOption,
+                        peerOption,
                         createMintSubsOption,
                         operationOption,
                         contractIdOption,
@@ -570,6 +577,12 @@ int main(int argc, char* argv[]) {
         eCritical("Invalid --network-port value");
         return EXIT_FAILURE;
     }
+    bool          api_port_ok = false;
+    const quint16 api_port    = parser.value(apiPortOption).toUShort(&api_port_ok);
+    if (!api_port_ok || api_port == 0) {
+        eCritical("Invalid --api-port value");
+        return EXIT_FAILURE;
+    }
 
     ExtraChainNodeWrapper* node_wrapper = new ExtraChainNodeWrapper(&app, false, false, network_port);
     auto                   node         = node_wrapper->node;
@@ -627,7 +640,10 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        if (node->account_controller()->count() == 0) {
+        if (parser.isSet(joinOption) && AccountController::profiles_list().empty()) {
+            const auto login_hash = Utils::calculate_hash((login + password).toStdString());
+            node->account_controller()->create_profile(login_hash, ActorType::User);
+        } else if (node->account_controller()->count() == 0) {
             std::string   loginHash;
             AutologinHash autologinHash;
             if (AutologinHash::is_available() && autologinHash.load()) {
@@ -696,21 +712,11 @@ int main(int argc, char* argv[]) {
 
         bool is_thoth = parser.isSet(thothOption);
         if (is_thoth || is_new_network) {
-            auto res = node->thoth_manager()->create_thoth_template();
+            auto res = node->thoth_manager()->create_thoth_dictionary();
             if (!res) {
-                eInfo("Can't create Thoth vector template");
+                eInfo("Can't create Thoth dictionary");
             } else {
-                eSuccess("Thoth vector template created");
-            }
-        }
-
-        bool is_thoth_vector = parser.isSet(thothOption);
-        if (is_thoth_vector || is_new_network) {
-            auto res = node->thoth_manager()->create_thoth_vector();
-            if (!res) {
-                eInfo("Can't create Thoth vector template");
-            } else {
-                eSuccess("Thoth vector created");
+                eSuccess("Thoth dictionary created");
             }
         }
 
@@ -783,7 +789,7 @@ int main(int argc, char* argv[]) {
             eSuccess("Token allocations backfill started in background");
         }
 
-        if (parser.isSet(createMintSubsOption) || is_new_network) {
+        if (parser.isSet(createMintSubsOption)) {
             QFile mint_file("minting_actor.json");
             if (!mint_file.open(QIODevice::ReadOnly)) {
                 eCritical("[create-mint-subs] failed to open minting_actor.json");
@@ -919,11 +925,27 @@ int main(int argc, char* argv[]) {
 
         QString api_token = parser.value(apiTokenOption);
         if (RUN_API && !api_token.isEmpty()) {
-            std::thread([node, token = api_token.toStdString()]() {
-                run_api(node, token);
+            std::thread([node, token = api_token.toStdString(), api_port]() {
+                run_api(node, token, api_port);
             }).detach();
         } else if (RUN_API) {
             eLog("[API] Not started: --api-token not provided");
+        }
+
+        for (const auto& endpoint : parser.values(peerOption)) {
+            const auto separator = endpoint.lastIndexOf(':');
+            if (separator <= 0) {
+                eWarning("[Console] Ignore invalid peer endpoint {}", endpoint.toStdString());
+                continue;
+            }
+            bool       port_ok = false;
+            const auto port    = endpoint.sliced(separator + 1).toUShort(&port_ok);
+            const auto host    = endpoint.first(separator).trimmed();
+            if (host.isEmpty() || !port_ok || port == 0) {
+                eWarning("[Console] Ignore invalid peer endpoint {}", endpoint.toStdString());
+                continue;
+            }
+            node->network()->connect_to_endpoint(host, port, true, true);
         }
 
         return;

--- a/main.cpp
+++ b/main.cpp
@@ -411,6 +411,7 @@ int main(int argc, char* argv[]) {
     QCommandLineOption dfsMode("dfs-mode", "Choose dfs mode: full / light", "mode");
     QCommandLineOption regenControls("regen-controls", "Regerarate controls");
     QCommandLineOption apiTokenOption("api-token", "API token (required to start REST API)", "api-token");
+    QCommandLineOption networkPortOption("network-port", "WebSocket listen port", "port", "17593");
     QCommandLineOption
                        createMintSubsOption("create-mint-subs",
                              "Register mint actor in profile and create SubscriptionsPay dictionary");
@@ -456,6 +457,7 @@ int main(int argc, char* argv[]) {
                         tokenAllocationsOption,
                         backfillTokenAllocationsOption,
                         apiTokenOption,
+                        networkPortOption,
                         createMintSubsOption,
                         operationOption,
                         contractIdOption,
@@ -562,7 +564,14 @@ int main(int argc, char* argv[]) {
     else
         console.startInput();
 
-    ExtraChainNodeWrapper* node_wrapper = new ExtraChainNodeWrapper(&app, false, false, 17593);
+    bool          network_port_ok = false;
+    const quint16 network_port    = parser.value(networkPortOption).toUShort(&network_port_ok);
+    if (!network_port_ok || network_port == 0) {
+        eCritical("Invalid --network-port value");
+        return EXIT_FAILURE;
+    }
+
+    ExtraChainNodeWrapper* node_wrapper = new ExtraChainNodeWrapper(&app, false, false, network_port);
     auto                   node         = node_wrapper->node;
     node_wrapper->init(true);
 
@@ -610,22 +619,12 @@ int main(int argc, char* argv[]) {
 
         QString importFile = parser.value(importOption);
         if (!importFile.isEmpty()) {
-            QFile file(importFile);
-            if (!file.open(QFile::ReadOnly)) {
-                eInfo("Can't open import file: {}", file.errorString());
-                std::exit(1);
-            }
-            auto data = file.readAll().toStdString();
-            if (data.empty()) {
-                eInfo("Incorrect import");
-                std::exit(1);
-            }
-            const auto imported = node->import_profile(data, login.toStdString(), password.toStdString());
+            const auto imported =
+                node->import_profile_file(importFile.toStdString(), login.toStdString(), password.toStdString());
             if (!imported.has_value()) {
                 eInfo("Can't import profile: {}", Utils::enum_value_name_value(imported.error()));
                 std::exit(1);
             }
-            file.close();
         }
 
         if (node->account_controller()->count() == 0) {

--- a/sources/console/console_api.cpp
+++ b/sources/console/console_api.cpp
@@ -19,16 +19,21 @@
 
 #include "console/console_api.h"
 
+#include <algorithm>
 #include "crow.h"
 #include <chrono>
 #include <mutex>
 #include <regex>
 #include <QFile>
+#include <QStandardPaths>
 
 #include "managers/extrachain_node.h"
 #include "contracts/contract_manager.h"
+#include "contracts/contract_codec.h"
+#include "contracts/toolchain_registry.h"
 #include "chain/dag.h"
 #include "dfs/dfs_controller.h"
+#include "managers/token_manager.h"
 #include "utils/exc_utils.h"
 #include <boost/describe.hpp>
 
@@ -39,38 +44,74 @@ struct SubscriptionRecord {
 BOOST_DESCRIBE_STRUCT(SubscriptionRecord, (), (until_ms, plan))
 
 namespace {
-std::string subscription_to_json(const SubscriptionRecord& rec) {
-    return Json::serialize(rec);
-}
+    std::expected<std::vector<std::uint8_t>, std::string> contract_arguments(const boost::json::object& json) {
+        const auto* raw   = json.if_contains("arguments_base64");
+        const auto* value = json.if_contains("arguments");
+        if (raw != nullptr && value != nullptr) {
+            return std::unexpected("arguments and arguments_base64 are mutually exclusive");
+        }
+        if (raw != nullptr) {
+            if (!raw->is_string()) {
+                return std::unexpected("arguments_base64 must be a string");
+            }
+            auto decoded = Utils::from_base64<std::vector<std::uint8_t>>(std::string(raw->as_string()));
+            if (!decoded.has_value()) {
+                return std::unexpected("arguments_base64 is invalid");
+            }
+            return *decoded;
+        }
+        if (value == nullptr) {
+            return std::vector<std::uint8_t> {};
+        }
+        auto encoded = ExtraChain::Contracts::Codec::encode_json(boost::json::serialize(*value));
+        if (!encoded.has_value()) {
+            return std::unexpected(encoded.error().detail);
+        }
+        return *encoded;
+    }
 
-SubscriptionRecord subscription_from_value(const std::string& raw) {
-    SubscriptionRecord rec;
-    if (raw.empty())
-        return rec;
-
-    // Legacy
-    const bool looks_numeric =
-        raw.find_first_not_of("0123456789") == std::string::npos;
-    if (looks_numeric) {
+    std::optional<boost::json::object> request_object(const crow::request& request) {
         try {
-            rec.until_ms = std::stoull(raw);
+            auto value = boost::json::parse(request.body);
+            if (value.is_object()) {
+                return value.as_object();
+            }
         } catch (...) {
+        }
+        return std::nullopt;
+    }
+
+    std::string subscription_to_json(const SubscriptionRecord& rec) {
+        return Json::serialize(rec);
+    }
+
+    SubscriptionRecord subscription_from_value(const std::string& raw) {
+        SubscriptionRecord rec;
+        if (raw.empty())
+            return rec;
+
+        // Legacy
+        const bool looks_numeric = raw.find_first_not_of("0123456789") == std::string::npos;
+        if (looks_numeric) {
+            try {
+                rec.until_ms = std::stoull(raw);
+            } catch (...) {
+            }
+            return rec;
+        }
+
+        // New
+        auto parsed = Json::deserialize<SubscriptionRecord>(raw);
+        if (parsed.has_value()) {
+            rec = parsed.value();
+        } else {
+            try {
+                rec.until_ms = std::stoull(raw);
+            } catch (...) {
+            }
         }
         return rec;
     }
-
-    // New
-    auto parsed = Json::deserialize<SubscriptionRecord>(raw);
-    if (parsed.has_value()) {
-        rec = parsed.value();
-    } else {
-        try {
-            rec.until_ms = std::stoull(raw);
-        } catch (...) {
-        }
-    }
-    return rec;
-}
 } // namespace
 
 long long parseTimeToMs(const std::string& time_str) {
@@ -110,33 +151,228 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
 
     auto load_mint_actor = []() -> std::optional<Actor<KeyPrivate>> {
         QFile f("minting_actor.json");
-        if (!f.open(QIODevice::ReadOnly)) return std::nullopt;
+        if (!f.open(QIODevice::ReadOnly))
+            return std::nullopt;
         auto a = Actor<KeyPrivate>::fromJson(f.readAll());
         f.close();
-        if (a.empty()) return std::nullopt;
+        if (a.empty())
+            return std::nullopt;
         return a;
     };
 
     auto check_token_post = [&](const crow::json::rvalue& json) -> std::optional<crow::response> {
-        if (!json.has("token")) return json_error(400, "token required");
+        if (!json.has("token"))
+            return json_error(400, "token required");
         std::string token = std::string(json["token"].s());
-        if (token.empty()) return json_error(400, "token is empty");
-        if (token != token_session) return json_error(400, "token is not valid");
+        if (token.empty())
+            return json_error(400, "token is empty");
+        if (token != token_session)
+            return json_error(400, "token is not valid");
         return std::nullopt;
     };
 
     auto check_token_get = [&](const crow::request& req) -> std::optional<crow::response> {
         auto token_raw = req.url_params.get("token");
-        if (!token_raw) return json_error(400, "token required");
+        if (!token_raw)
+            return json_error(400, "token required");
         std::string token(token_raw);
-        if (token.empty()) return json_error(400, "token is empty");
-        if (token != token_session) return json_error(400, "token is not valid");
+        if (token.empty())
+            return json_error(400, "token is empty");
+        if (token != token_session)
+            return json_error(400, "token is not valid");
         return std::nullopt;
     };
 
+    CROW_ROUTE(app, "/contract/list").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        ExtraChain::Contracts::ContractCatalogFilter filter;
+        if (const auto owner = req.url_params.get("owner_id"))
+            filter.owner_id = owner;
+        if (const auto kind = req.url_params.get("kind"))
+            filter.kind = kind;
+        if (const auto cursor = req.url_params.get("cursor"))
+            filter.cursor = cursor;
+        if (const auto limit = req.url_params.get("limit")) {
+            try {
+                filter.limit = std::stoull(limit);
+            } catch (...) {
+                return json_error(400, "limit is invalid");
+            }
+        }
+        auto response = crow::response(200, Json::serialize(node->list_contracts(filter)));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/token/create").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* name   = object->if_contains("name");
+        const auto* ticker = object->if_contains("ticker");
+        const auto* count  = object->if_contains("count");
+        if (name == nullptr || ticker == nullptr || count == nullptr || !name->is_string() || !ticker->is_string()
+            || !count->is_string())
+            return json_error(400, "name, ticker and count required");
+        const auto count_text = std::string(count->as_string());
+        if (!std::regex_match(count_text, std::regex(R"([0-9]+(?:\.[0-9]+)?)")))
+            return json_error(400, "count must be a positive decimal string");
+        const auto wallet = node->account_controller()->current_wallet();
+        if (wallet.empty())
+            return json_error(409, "current wallet is not available");
+        std::uint8_t decimals = 8;
+        if (const auto* value = object->if_contains("decimals")) {
+            if (!value->is_int64())
+                return json_error(400, "decimals must be an integer");
+            const auto parsed = value->as_int64();
+            if (parsed < 0 || parsed > 18)
+                return json_error(400, "decimals must be between 0 and 18");
+            decimals = static_cast<std::uint8_t>(parsed);
+        }
+        const auto optional_string = [&](std::string_view key, std::string fallback = {}) {
+            const auto* value = object->if_contains(key);
+            return value != nullptr && value->is_string() ? std::string(value->as_string()) : std::move(fallback);
+        };
+        const std::string color      = optional_string("color", "#FA5448");
+        const std::string predefined = optional_string("predefined_token_id");
+        auto              created    = node->token_manager()->create_token(wallet.id(),
+                                                           std::string(name->as_string()),
+                                                           std::string(ticker->as_string()),
+                                                           BigNumberFloat(count_text),
+                                                           color,
+                                                           predefined,
+                                                           decimals);
+        if (!created.has_value())
+            return json_error(409, "token creation was rejected");
+        crow::json::wvalue response;
+        response["token_id"] = created->token_id.to_string();
+        response["owner_id"] = created->owner_id.to_string();
+        response["name"]     = created->name;
+        response["ticker"]   = created->ticker;
+        response["count"]    = created->count.to_string();
+        return crow::response(202, response);
+    });
+
+    CROW_ROUTE(app, "/toolchain/status").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        const auto manifest = node->toolchain_registry()->manifest();
+        if (!manifest.has_value())
+            return json_error(404, manifest.error().detail);
+        auto response = crow::response(200, Json::serialize(*manifest));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/toolchain/install").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto first_install = object->if_contains("first_install");
+        const auto allow_first = first_install != nullptr && first_install->is_bool() && first_install->as_bool();
+        const auto root =
+            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+        ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+        const auto                                result = installer.install_stable(allow_first);
+        if (!result.has_value())
+            return json_error(409, result.error().detail);
+        auto response = crow::response(200, Json::serialize(result->manifest));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/contract/build").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* project_name = object->if_contains("project_name");
+        const auto* source       = object->if_contains("source");
+        if (project_name == nullptr || source == nullptr || !project_name->is_string() || !source->is_string())
+            return json_error(400, "project_name and source strings required");
+        const auto root =
+            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+        ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+        const auto                                result =
+            installer.build_contract(QString::fromStdString(std::string(source->as_string())),
+                                     QString::fromStdString(std::string(project_name->as_string())));
+        if (!result.has_value())
+            return json_error(409, result.error().detail);
+        boost::json::object body;
+        body["module"] = result->toStdString();
+        auto response  = crow::response(200, boost::json::serialize(body));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/toolchain/publish-package").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto text = [&](std::string_view key) -> std::optional<std::string> {
+            const auto* value = object->if_contains(key);
+            if (value == nullptr || !value->is_string() || value->as_string().empty())
+                return std::nullopt;
+            return std::string(value->as_string());
+        };
+        const auto platform       = text("platform");
+        const auto architecture   = text("architecture");
+        const auto archive_format = text("archive_format");
+        const auto version        = text("version");
+        const auto data           = text("data_base64");
+        if (!platform || !architecture || !archive_format || !version || !data)
+            return json_error(400, "platform, architecture, archive_format, version and data_base64 required");
+        const auto decoded = Utils::from_base64<std::vector<std::uint8_t>>(*data);
+        if (!decoded.has_value() || decoded->empty())
+            return json_error(400, "data_base64 is invalid");
+        const auto result = node->toolchain_registry()->publish_package(*platform,
+                                                                        *architecture,
+                                                                        *archive_format,
+                                                                        *version,
+                                                                        *decoded);
+        if (!result.has_value())
+            return json_error(409, result.error().detail);
+        auto response = crow::response(202, Json::serialize(*result));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/toolchain/publish-manifest").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* manifest_value = object->if_contains("manifest");
+        if (manifest_value == nullptr || !manifest_value->is_object())
+            return json_error(400, "manifest object required");
+        const auto manifest =
+            Json::deserialize<ExtraChain::Contracts::ToolchainManifest>(boost::json::serialize(*manifest_value));
+        if (!manifest.has_value())
+            return json_error(400, "manifest is invalid");
+        const auto result = node->toolchain_registry()->publish_manifest(*manifest);
+        if (!result.has_value())
+            return json_error(409, result.error().detail);
+        return crow::response(202);
+    });
+
     CROW_ROUTE(app, "/contract/deploy").methods("POST"_method)([&](const crow::request& req) {
-        auto json = crow::json::load(req.body);
-        if (!json)
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
             return json_error(400, "invalid json");
         if (auto err = check_token_post(json))
             return std::move(*err);
@@ -144,8 +380,7 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
             return json_error(400, "kind and module_base64 required");
         }
         auto module    = Utils::from_base64<std::vector<std::uint8_t>>(std::string(json["module_base64"].s()));
-        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
-            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        auto arguments = contract_arguments(*object);
         if (!module.has_value() || module->empty() || !arguments.has_value()) {
             return json_error(400, "invalid module or arguments");
         }
@@ -156,13 +391,14 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         crow::json::wvalue response;
         response["contract_id"]      = transaction->receiver().to_string();
         response["transaction_hash"] = transaction->hash();
-        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        response["section"]          = transaction->section().to_string();
         return crow::response(202, response);
     });
 
     CROW_ROUTE(app, "/contract/call").methods("POST"_method)([&](const crow::request& req) {
-        auto json = crow::json::load(req.body);
-        if (!json)
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
             return json_error(400, "invalid json");
         if (auto err = check_token_post(json))
             return std::move(*err);
@@ -172,23 +408,23 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         auto contract_id = ActorId::create(std::string(json["contract_id"].s()));
         if (!contract_id.has_value())
             return json_error(400, "invalid contract_id");
-        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
-            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        auto arguments = contract_arguments(*object);
         if (!arguments.has_value())
-            return json_error(400, "invalid arguments_base64");
+            return json_error(400, arguments.error());
         auto transaction = node->submit_contract_call(*contract_id, std::string(json["method"].s()), *arguments);
         if (!transaction.has_value())
             return json_error(409, transaction.error().detail);
 
         crow::json::wvalue response;
         response["transaction_hash"] = transaction->hash();
-        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        response["section"]          = transaction->section().to_string();
         return crow::response(202, response);
     });
 
     CROW_ROUTE(app, "/contract/query").methods("POST"_method)([&](const crow::request& req) {
-        auto json = crow::json::load(req.body);
-        if (!json)
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
             return json_error(400, "invalid json");
         if (auto err = check_token_post(json))
             return std::move(*err);
@@ -198,20 +434,25 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         auto contract_id = ActorId::create(std::string(json["contract_id"].s()));
         if (!contract_id.has_value())
             return json_error(400, "invalid contract_id");
-        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
-            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        auto arguments = contract_arguments(*object);
         if (!arguments.has_value())
-            return json_error(400, "invalid arguments_base64");
+            return json_error(400, arguments.error());
         auto receipt = node->query_contract(*contract_id, std::string(json["method"].s()), *arguments);
         if (!receipt.has_value())
             return json_error(409, receipt.error().detail);
 
-        crow::json::wvalue response;
+        boost::json::object response;
         response["data_base64"] = Utils::to_base64(receipt->data);
-        response["state_hash"]  = receipt->state_hash;
-        response["version"]     = receipt->version;
-        response["revision"]    = receipt->revision;
-        return crow::response(200, response);
+        if (const auto data_json = ExtraChain::Contracts::Codec::decode_json(receipt->data);
+            data_json.has_value()) {
+            response["data"] = boost::json::parse(*data_json);
+        }
+        response["state_hash"] = receipt->state_hash;
+        response["version"]    = receipt->version;
+        response["revision"]   = receipt->revision;
+        auto result            = crow::response(200, boost::json::serialize(response));
+        result.set_header("Content-Type", "application/json");
+        return result;
     });
 
     CROW_ROUTE(app, "/contract/inspect").methods("GET"_method)([&](const crow::request& req) {
@@ -242,8 +483,9 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
     });
 
     CROW_ROUTE(app, "/contract/upgrade").methods("POST"_method)([&](const crow::request& req) {
-        auto json = crow::json::load(req.body);
-        if (!json)
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
             return json_error(400, "invalid json");
         if (auto err = check_token_post(json))
             return std::move(*err);
@@ -254,8 +496,7 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         if (!contract_id.has_value())
             return json_error(400, "invalid contract_id");
         auto module    = Utils::from_base64<std::vector<std::uint8_t>>(std::string(json["module_base64"].s()));
-        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
-            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        auto arguments = contract_arguments(*object);
         if (!module.has_value() || module->empty() || !arguments.has_value()) {
             return json_error(400, "invalid module or arguments");
         }
@@ -265,23 +506,28 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
 
         crow::json::wvalue response;
         response["transaction_hash"] = transaction->hash();
-        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        response["section"]          = transaction->section().to_string();
         return crow::response(202, response);
     });
 
     CROW_ROUTE(app, "/balance").methods("POST"_method)([&](const crow::request& req) {
         auto json = crow::json::load(req.body);
-        if (!json) return json_error(400, "invalid json");
-        if (auto err = check_token_post(json)) return std::move(*err);
-        if (!json.has("actor_id")) return json_error(400, "actor_id required");
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("actor_id"))
+            return json_error(400, "actor_id required");
 
         std::string actorIdStr = json["actor_id"].s();
         auto        actor_id   = ActorId::create(actorIdStr);
-        if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
         TokenId tokenId("468faf2f1be6504a9a26f7f027f7e43380b0d77d");
 
-        if (!node->actor_index()->exists(actor_id.value())) return json_error(404, "actor not found");
+        if (!node->actor_index()->exists(actor_id.value()))
+            return json_error(404, "actor not found");
 
         eLog("[api] [POST] [balance] [actor_id: {}]", actorIdStr);
 
@@ -297,123 +543,146 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
 
         crow::json::wvalue response;
         response["actor_id"] = actor_id.value().to_string();
-        response["balance"]  = balance.to_string(NumeralBase::Dec);
+        response["balance"]  = balance.to_string();
         return crow::response(200, response);
     });
 
-    CROW_ROUTE(app, "/transaction_by_hash_and_section_id")
-        .methods("POST"_method)([&](const crow::request& req) {
-            auto json = crow::json::load(req.body);
-            if (!json) return json_error(400, "invalid json");
-            if (auto err = check_token_post(json)) return std::move(*err);
-            if (!json.has("hash")) return json_error(400, "hash required");
-            if (!json.has("section_id")) return json_error(400, "section_id required");
+    CROW_ROUTE(app, "/transaction_by_hash_and_section_id").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("hash"))
+            return json_error(400, "hash required");
+        if (!json.has("section_id"))
+            return json_error(400, "section_id required");
 
-            std::string hash          = json["hash"].s();
-            int         sectionNumber = json["section_id"].i();
-            auto        section       = node->dag()->read_section(SectionId(sectionNumber));
-            if (!section.has_value()) return json_error(400, "section not found");
+        std::string hash          = json["hash"].s();
+        int         sectionNumber = json["section_id"].i();
+        auto        section       = node->dag()->read_section(SectionId(sectionNumber));
+        if (!section.has_value())
+            return json_error(400, "section not found");
 
-            auto transactions = section->transactions;
-            if (transactions.empty()) return json_error(400, "list transactions is empty");
+        auto transactions = section->transactions;
+        if (transactions.empty())
+            return json_error(400, "list transactions is empty");
 
-            eLog("[api] [POST] [transaction_by_hash_and_section_id] [hash: {}]", hash);
+        eLog("[api] [POST] [transaction_by_hash_and_section_id] [hash: {}]", hash);
 
-            auto it = std::find_if(transactions.begin(), transactions.end(), [&hash](const Transaction& t) {
-                return t.hash() == hash;
-            });
-
-            if (it == transactions.end()) return json_error(400, "transaction not found");
-
-            Transaction        tx = *it;
-            crow::json::wvalue response;
-            response["hash"]     = hash;
-            response["sender"]   = tx.sender().to_string();
-            response["receiver"] = tx.receiver().to_string();
-            response["amount"]   = tx.amount().to_string(NumeralBase::Dec);
-            auto dateTime        = QDateTime::fromMSecsSinceEpoch(tx.timestamp());
-            response["date"]     = dateTime.toString("dd/MM/yyyy").toStdString();
-            response["time"]     = dateTime.toString("hh:mm:ss").toStdString();
-            std::string typeTx;
-            switch (tx.type()) {
-            case TransactionType::Genesis:     typeTx = "genesis";       break;
-            case TransactionType::Balance:     typeTx = "balance";       break;
-            case TransactionType::Burn:        typeTx = "burn";          break;
-            case TransactionType::InitContract: typeTx = "init_contract"; break;
-            case TransactionType::Conversion:  typeTx = "conversion";    break;
-            case TransactionType::Regular:     typeTx = "regular";       break;
-            case TransactionType::Repeatable:  typeTx = "repeatable";    break;
-            case TransactionType::Reward:      typeTx = "reward";        break;
-            case TransactionType::Minting:     typeTx = "minting";       break;
-            default:                                                       break;
-            }
-            response["type"] = typeTx;
-            return crow::response(200, response);
+        auto it = std::find_if(transactions.begin(), transactions.end(), [&hash](const Transaction& t) {
+            return t.hash() == hash;
         });
 
-    CROW_ROUTE(app, "/count_sections")
-        .methods("GET"_method)([&](const crow::request& req) {
-            if (auto err = check_token_get(req)) return std::move(*err);
-            eLog("[api] [GET] [count_sections]");
-            crow::json::wvalue response;
-            response["count_sections"] = node->dag()->current_section().to_string(NumeralBase::Dec);
-            return crow::response(200, response);
-        });
+        if (it == transactions.end())
+            return json_error(400, "transaction not found");
 
-    CROW_ROUTE(app, "/count_transactions_in_section")
-        .methods("GET"_method)([&](const crow::request& req) {
-            if (auto err = check_token_get(req)) return std::move(*err);
+        Transaction        tx = *it;
+        crow::json::wvalue response;
+        response["hash"]     = hash;
+        response["sender"]   = tx.sender().to_string();
+        response["receiver"] = tx.receiver().to_string();
+        response["amount"]   = tx.amount().to_string();
+        auto dateTime        = QDateTime::fromMSecsSinceEpoch(tx.timestamp());
+        response["date"]     = dateTime.toString("dd/MM/yyyy").toStdString();
+        response["time"]     = dateTime.toString("hh:mm:ss").toStdString();
+        std::string typeTx;
+        switch (tx.type()) {
+        case TransactionType::Genesis:
+            typeTx = "genesis";
+            break;
+        case TransactionType::Balance:
+            typeTx = "balance";
+            break;
+        case TransactionType::Burn:
+            typeTx = "burn";
+            break;
+        case TransactionType::InitContract:
+            typeTx = "init_contract";
+            break;
+        case TransactionType::Conversion:
+            typeTx = "conversion";
+            break;
+        case TransactionType::Regular:
+            typeTx = "regular";
+            break;
+        case TransactionType::Repeatable:
+            typeTx = "repeatable";
+            break;
+        case TransactionType::Reward:
+            typeTx = "reward";
+            break;
+        case TransactionType::Minting:
+            typeTx = "minting";
+            break;
+        default:
+            break;
+        }
+        response["type"] = typeTx;
+        return crow::response(200, response);
+    });
 
-            auto number_section = req.url_params.get("number_section");
-            if (!number_section) return json_error(400, "number_section required");
+    CROW_ROUTE(app, "/count_sections").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        eLog("[api] [GET] [count_sections]");
+        crow::json::wvalue response;
+        response["count_sections"] = node->dag()->current_section().to_string();
+        return crow::response(200, response);
+    });
 
-            int  section_number = std::stoi(number_section);
-            auto section        = node->dag()->read_section(BigNumber(section_number));
-            if (!section.has_value()) return json_error(400, "invalid number section");
+    CROW_ROUTE(app, "/count_transactions_in_section").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
 
-            eLog("[api] [GET] [count_transactions_in_section] [number_section: {}]", number_section);
+        auto number_section = req.url_params.get("number_section");
+        if (!number_section)
+            return json_error(400, "number_section required");
 
-            crow::json::wvalue response;
-            response["count_transactions"] = section->transactions.size();
-            response["section_number"]     = number_section;
-            return crow::response(200, response);
-        });
+        int  section_number = std::stoi(number_section);
+        auto section        = node->dag()->read_section(BigNumber(section_number));
+        if (!section.has_value())
+            return json_error(400, "invalid number section");
+
+        eLog("[api] [GET] [count_transactions_in_section] [number_section: {}]", number_section);
+
+        crow::json::wvalue response;
+        response["count_transactions"] = section->transactions.size();
+        response["section_number"]     = number_section;
+        return crow::response(200, response);
+    });
 
     CROW_ROUTE(app, "/have_rewards").methods("POST"_method)([&](const crow::request& req) {
         auto json = crow::json::load(req.body);
-        if (!json) return json_error(400, "invalid json");
-        if (auto err = check_token_post(json)) return std::move(*err);
-        if (!json.has("actor_id")) return json_error(400, "actor_id required");
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("actor_id"))
+            return json_error(400, "actor_id required");
 
         std::string actorId  = json["actor_id"].s();
         std::string period   = json.has("period") ? json["period"].s() : std::string();
         long long   periodMs = parseTimeToMs(period);
 
         auto actor_id = ActorId::create(actorId);
-        if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
-        auto now          = std::chrono::system_clock::now().time_since_epoch();
-        auto cutoffTimeMs = static_cast<std::uint64_t>(now.count() - periodMs);
+        const auto nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count();
+        const auto cutoffTimeMs = static_cast<std::uint64_t>(std::max<std::int64_t>(0, nowMs - periodMs));
 
-        bool hasRewards  = false;
-        int  rewardCount = 0;
+        const auto* chainIndex = node->dag()->chain_index();
+        if (!chainIndex)
+            return json_error(503, "chain index is disabled");
 
-        const std::vector<BigNumber> sections = node->dag()->cache().read_index(actor_id.value());
-        for (const auto& section_id : sections) {
-            auto section = node->dag()->read_section(section_id);
-            if (!section.has_value()) continue;
-
-            for (const auto& tx : section.value().transactions) {
-                if (tx.type() == TransactionType::Reward) {
-                    if (tx.timestamp() >= cutoffTimeMs) {
-                        hasRewards = true;
-                        rewardCount++;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
+        const auto rewardCount =
+            chainIndex->count_for_actor_by_type_since(actor_id->to_string(),
+                                                      static_cast<int>(TransactionType::Reward),
+                                                      cutoffTimeMs);
+        const bool hasRewards = rewardCount > 0;
 
         crow::json::wvalue response;
         response["actor_id"]     = actor_id.value().to_string();
@@ -424,192 +693,231 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         return crow::response(200, response);
     });
 
-    CROW_ROUTE(app, "/subscription_state")
-        .methods("POST"_method)([&](const crow::request& req) {
-            auto json = crow::json::load(req.body);
-            if (!json) return json_error(400, "invalid json");
-            if (auto err = check_token_post(json)) return std::move(*err);
-            if (!json.has("actor_id")) return json_error(400, "actor_id required");
+    CROW_ROUTE(app, "/subscription_state").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("actor_id"))
+            return json_error(400, "actor_id required");
 
-            std::string actorId  = json["actor_id"].s();
-            auto        actor_id = ActorId::create(actorId);
-            if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        std::string actorId  = json["actor_id"].s();
+        auto        actor_id = ActorId::create(actorId);
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
-            auto raccoon_id = ActorId("46710a2d823c23db9fc2ac01e0f84212a8128373");
+        auto raccoon_id = ActorId("46710a2d823c23db9fc2ac01e0f84212a8128373");
 
-            auto search_result =
-                Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(node->dfs()->get_db_instance(),
-                                                                                  raccoon_id,
-                                                                                  Dfs::Basic::TEMPLATE_VECTOR,
-                                                                                  "RaccoonSubscription");
-            if (!search_result.has_value()) return json_error(400, "can not find subscription");
+        auto search_result =
+            Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(node->dfs()->get_db_instance(),
+                                                                              raccoon_id,
+                                                                              Dfs::Basic::TEMPLATE_VECTOR,
+                                                                              "RaccoonSubscription");
+        if (!search_result.has_value())
+            return json_error(400, "can not find subscription");
 
-            bool subscribeActive = search_result->state == Dfs::FileState::Ready;
-            bool subscribed      = false;
+        bool subscribeActive = search_result->state == Dfs::FileState::Ready;
+        bool subscribed      = false;
 
-            eLog("[api] [POST] [subscription_state] [actor_id: {}]", actorId);
-            auto row = node->dfs()->read_vector_row(raccoon_id, search_result->file_id, actor_id->to_string());
-            subscribed = row.has_value();
+        eLog("[api] [POST] [subscription_state] [actor_id: {}]", actorId);
+        auto row   = node->dfs()->read_vector_row(raccoon_id, search_result->file_id, actor_id->to_string());
+        subscribed = row.has_value();
 
-            crow::json::wvalue response;
-            response["actor_id"]   = actor_id.value().to_string();
-            response["active"]     = subscribeActive;
-            response["subscribed"] = subscribed;
-            return crow::response(200, response);
-        });
+        crow::json::wvalue response;
+        response["actor_id"]   = actor_id.value().to_string();
+        response["active"]     = subscribeActive;
+        response["subscribed"] = subscribed;
+        return crow::response(200, response);
+    });
 
-    CROW_ROUTE(app, "/get_actor")
-        .methods("GET"_method)([&](const crow::request& req) {
-            if (auto err = check_token_get(req)) return std::move(*err);
+    CROW_ROUTE(app, "/get_actor").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
 
-            auto id = req.url_params.get("id");
-            if (!id) return json_error(400, "id required");
+        auto id = req.url_params.get("id");
+        if (!id)
+            return json_error(400, "id required");
 
-            auto actor_id = ActorId::create(id);
-            if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        auto actor_id = ActorId::create(id);
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
-            auto res = node->actor_index()->read_actor(actor_id.value());
-            if (!res.has_value()) return json_error(400, "No actor");
+        auto res = node->actor_index()->read_actor(actor_id.value());
+        if (!res.has_value())
+            return json_error(400, "No actor");
 
-            crow::json::wvalue response;
-            response["public_key"] = Utils::to_base64(res.value().key().public_key());
-            return crow::response(200, response);
-        });
+        crow::json::wvalue response;
+        response["public_key"] = Utils::to_base64(res.value().key().public_key());
+        return crow::response(200, response);
+    });
 
-    CROW_ROUTE(app, "/verify_actor")
-        .methods("GET"_method)([&](const crow::request& req) {
-            if (auto err = check_token_get(req)) return std::move(*err);
+    CROW_ROUTE(app, "/verify_actor").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
 
-            auto id      = req.url_params.get("id");
-            auto sig_str = req.url_params.get("signature");
-            if (!id) return json_error(400, "id required");
-            if (!sig_str) return json_error(400, "signature required");
+        auto id      = req.url_params.get("id");
+        auto sig_str = req.url_params.get("signature");
+        if (!id)
+            return json_error(400, "id required");
+        if (!sig_str)
+            return json_error(400, "signature required");
 
-            auto actor_id = ActorId::create(id);
-            if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        auto actor_id = ActorId::create(id);
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
-            auto actor_data = node->actor_index()->read_actor(actor_id.value());
-            if (!actor_data.has_value()) return json_error(400, "No actor");
+        auto actor_data = node->actor_index()->read_actor(actor_id.value());
+        if (!actor_data.has_value())
+            return json_error(400, "No actor");
 
-            auto decoded_sig = Utils::from_base64<std::vector<std::uint8_t>>(sig_str);
-            if (!decoded_sig) return json_error(400, "Base64 decoding failed");
+        auto decoded_sig = Utils::from_base64<std::vector<std::uint8_t>>(sig_str);
+        if (!decoded_sig)
+            return json_error(400, "Base64 decoding failed");
 
-            const auto& decoded = decoded_sig.value();
-            if (decoded.size() != crypto_sign_BYTES) return json_error(400, "Invalid signature length");
+        const auto& decoded = decoded_sig.value();
+        if (decoded.size() != crypto_sign_BYTES)
+            return json_error(400, "Invalid signature length");
 
-            Signature signature;
-            std::copy(decoded.begin(), decoded.end(), signature.begin());
+        Signature signature;
+        std::copy(decoded.begin(), decoded.end(), signature.begin());
 
-            auto res = actor_data->key().verify(id, signature);
-            if (!res.has_value()) return json_error(400, "verification failed");
+        auto res = actor_data->key().verify(id, signature);
+        if (!res.has_value())
+            return json_error(400, "verification failed");
 
-            crow::json::wvalue response;
-            response["result"] = res.value();
-            return crow::response(200, response);
-        });
+        crow::json::wvalue response;
+        response["result"] = res.value();
+        return crow::response(200, response);
+    });
 
-    CROW_ROUTE(app, "/verify_data")
-        .methods("POST"_method)([&](const crow::request& req) {
-            auto json = crow::json::load(req.body);
-            if (!json) return json_error(400, "invalid json");
-            if (auto err = check_token_post(json)) return std::move(*err);
-            if (!json.has("id")) return json_error(400, "id required");
-            if (!json.has("data")) return json_error(400, "data required");
-            if (!json.has("signature")) return json_error(400, "signature required");
+    CROW_ROUTE(app, "/verify_data").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("id"))
+            return json_error(400, "id required");
+        if (!json.has("data"))
+            return json_error(400, "data required");
+        if (!json.has("signature"))
+            return json_error(400, "signature required");
 
-            std::string id_str   = json["id"].s();
-            std::string data_str = json["data"].s();
-            std::string sig_str  = json["signature"].s();
+        std::string id_str   = json["id"].s();
+        std::string data_str = json["data"].s();
+        std::string sig_str  = json["signature"].s();
 
-            auto actor_id = ActorId::create(id_str);
-            if (!actor_id.has_value()) return json_error(400, "invalid actor_id");
+        auto actor_id = ActorId::create(id_str);
+        if (!actor_id.has_value())
+            return json_error(400, "invalid actor_id");
 
-            auto actor_data = node->actor_index()->read_actor(actor_id.value());
-            if (!actor_data.has_value()) return json_error(400, "No actor");
+        auto actor_data = node->actor_index()->read_actor(actor_id.value());
+        if (!actor_data.has_value())
+            return json_error(400, "No actor");
 
-            auto decoded_sig = Utils::from_base64<std::vector<std::uint8_t>>(sig_str);
-            if (!decoded_sig) return json_error(400, "Base64 decoding failed");
+        auto decoded_sig = Utils::from_base64<std::vector<std::uint8_t>>(sig_str);
+        if (!decoded_sig)
+            return json_error(400, "Base64 decoding failed");
 
-            const auto& decoded = decoded_sig.value();
-            if (decoded.size() != crypto_sign_BYTES) return json_error(400, "Invalid signature length");
+        const auto& decoded = decoded_sig.value();
+        if (decoded.size() != crypto_sign_BYTES)
+            return json_error(400, "Invalid signature length");
 
-            Signature signature;
-            std::copy(decoded.begin(), decoded.end(), signature.begin());
+        Signature signature;
+        std::copy(decoded.begin(), decoded.end(), signature.begin());
 
-            auto res = actor_data->key().verify(data_str, signature);
-            if (!res.has_value()) return json_error(400, "verification failed");
+        auto res = actor_data->key().verify(data_str, signature);
+        if (!res.has_value())
+            return json_error(400, "verification failed");
 
-            crow::json::wvalue response;
-            response["result"] = res.value();
-            return crow::response(200, response);
-        });
+        crow::json::wvalue response;
+        response["result"] = res.value();
+        return crow::response(200, response);
+    });
 
     static std::mutex mint_mutex;
     CROW_ROUTE(app, "/mint").methods("POST"_method)([&](const crow::request& req) -> crow::response {
         try {
-        auto json = crow::json::load(req.body);
-        if (!json) return json_error(400, "invalid json");
-        if (auto err = check_token_post(json)) return std::move(*err);
-        if (!json.has("actor_id")) return json_error(400, "actor_id required");
-        if (!json.has("amount")) return json_error(400, "amount required");
+            auto json = crow::json::load(req.body);
+            if (!json)
+                return json_error(400, "invalid json");
+            if (auto err = check_token_post(json))
+                return std::move(*err);
+            if (!json.has("actor_id"))
+                return json_error(400, "actor_id required");
+            if (!json.has("amount"))
+                return json_error(400, "amount required");
 
-        std::string actorIdStr = json["actor_id"].s();
-        auto        receiver   = ActorId::create(actorIdStr);
-        if (!receiver.has_value()) return json_error(400, "invalid actor_id");
+            std::string actorIdStr = json["actor_id"].s();
+            auto        receiver   = ActorId::create(actorIdStr);
+            if (!receiver.has_value())
+                return json_error(400, "invalid actor_id");
 
-        if (!node->actor_index()->exists(receiver.value())) return json_error(404, "actor not found");
+            if (!node->actor_index()->exists(receiver.value()))
+                return json_error(404, "actor not found");
 
-        std::string amountStr  = json["amount"].s();
-        auto        amount_res = BigNumberFloat::create(amountStr, NumeralBase::Dec);
-        if (!amount_res.has_value()) return json_error(400, "invalid amount");
-        BigNumberFloat amount = amount_res.value();
-        if (amount <= 0) return json_error(400, "amount must be positive");
-        if (amount > 5000) return json_error(400, "amount exceeds maximum of 5000");
+            std::string amountStr  = json["amount"].s();
+            auto        amount_res = BigNumberFloat::create(amountStr);
+            if (!amount_res.has_value())
+                return json_error(400, "invalid amount");
+            BigNumberFloat amount = amount_res.value();
+            if (amount <= 0)
+                return json_error(400, "amount must be positive");
+            if (amount > 5000)
+                return json_error(400, "amount exceeds maximum of 5000");
 
-        auto owner_opt = load_mint_actor();
-        if (!owner_opt.has_value()) return json_error(500, "failed to load owner actor");
-        auto owner_actor = owner_opt.value();
+            auto owner_opt = load_mint_actor();
+            if (!owner_opt.has_value())
+                return json_error(500, "failed to load owner actor");
+            auto owner_actor = owner_opt.value();
 
-        Transaction tx;
-        tx.set_sender(owner_actor.id());
-        tx.set_receiver(receiver.value());
-        tx.set_amount(amount);
-        tx.set_token(TokenId("468faf2f1be6504a9a26f7f027f7e43380b0d77d"));
-        tx.set_type(TransactionType::Minting);
+            Transaction tx;
+            tx.set_sender(owner_actor.id());
+            tx.set_receiver(receiver.value());
+            tx.set_amount(amount);
+            tx.set_token(TokenId("468faf2f1be6504a9a26f7f027f7e43380b0d77d"));
+            tx.set_type(TransactionType::Minting);
 
-        std::lock_guard<std::mutex> lock(mint_mutex);
-        auto result = node->dag()->send_transaction(tx, owner_actor);
-        if (!result.has_value()) {
-            return json_error(500, "transaction failed: " + Utils::enum_value_name_value(result.error()));
-        }
-
-        // Update token_allocations dictionary: accumulate minted amount for this actor
-        auto network_id = node->actor_index()->network_id();
-        auto alloc_row  = Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(
-            node->dfs()->get_db_instance(), network_id, Dfs::Basic::TEMPLATE_DICTIONARY, "token_allocations");
-        if (alloc_row.has_value()) {
-            std::string alloc_key = fmt::format("{}:{}", actorIdStr, tx.token().to_string());
-            auto           current_str   = node->dfs()->read_dictionary(network_id, alloc_row->file_id, alloc_key);
-            BigNumberFloat current_minted(0);
-            if (current_str.has_value() && !current_str->empty()) {
-                auto parsed = BigNumberFloat::create(*current_str, NumeralBase::Dec);
-                if (parsed.has_value())
-                    current_minted = parsed.value();
+            std::lock_guard<std::mutex> lock(mint_mutex);
+            auto                        result = node->dag()->send_transaction(tx, owner_actor);
+            if (!result.has_value()) {
+                return json_error(500, "transaction failed: " + Utils::enum_value_name_value(result.error()));
             }
-            current_minted += amount;
-            node->dfs()->dictionary_set_value(network_id, alloc_row->file_id, alloc_key,
-                                              current_minted.to_string(NumeralBase::Dec), network_id);
-        } else {
-            eWarning("[api] [mint] token_allocations dictionary not found, skipping freeze tracking");
-        }
 
-        eLog("[api] [POST] [mint] [receiver: {}] [amount: {}]", actorIdStr, amountStr);
+            // Update token_allocations dictionary: accumulate minted amount for this actor
+            auto network_id = node->actor_index()->network_id();
+            auto alloc_row =
+                Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(node->dfs()->get_db_instance(),
+                                                                                  network_id,
+                                                                                  Dfs::Basic::TEMPLATE_DICTIONARY,
+                                                                                  "token_allocations");
+            if (alloc_row.has_value()) {
+                std::string alloc_key   = fmt::format("{}:{}", actorIdStr, tx.token().to_string());
+                auto        current_str = node->dfs()->read_dictionary(network_id, alloc_row->file_id, alloc_key);
+                BigNumberFloat current_minted(0);
+                if (current_str.has_value() && !current_str->empty()) {
+                    auto parsed = BigNumberFloat::create(*current_str);
+                    if (parsed.has_value())
+                        current_minted = parsed.value();
+                }
+                current_minted += amount;
+                node->dfs()->dictionary_set_value(network_id,
+                                                  alloc_row->file_id,
+                                                  alloc_key,
+                                                  current_minted.to_string(),
+                                                  network_id);
+            } else {
+                eWarning("[api] [mint] token_allocations dictionary not found, skipping freeze tracking");
+            }
 
-        crow::json::wvalue response;
-        response["hash"]     = result.value().hash();
-        response["receiver"] = receiver.value().to_string();
-        response["amount"]   = amountStr;
-        return crow::response(200, response);
+            eLog("[api] [POST] [mint] [receiver: {}] [amount: {}]", actorIdStr, amountStr);
+
+            crow::json::wvalue response;
+            response["hash"]     = result.value().hash();
+            response["receiver"] = receiver.value().to_string();
+            response["amount"]   = amountStr;
+            return crow::response(200, response);
         } catch (const std::exception& e) {
             return json_error(500, fmt::format("internal error: {}", e.what()));
         } catch (...) {
@@ -621,47 +929,65 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
     CROW_ROUTE(app, "/subscription_add").methods("POST"_method)([&](const crow::request& req) -> crow::response {
         try {
             auto json = crow::json::load(req.body);
-            if (!json) return json_error(400, "invalid json");
-            if (auto err = check_token_post(json)) return std::move(*err);
-            if (!json.has("actor_id")) return json_error(400, "actor_id required");
-            if (!json.has("until_ms")) return json_error(400, "until_ms required");
+            if (!json)
+                return json_error(400, "invalid json");
+            if (auto err = check_token_post(json))
+                return std::move(*err);
+            if (!json.has("actor_id"))
+                return json_error(400, "actor_id required");
+            if (!json.has("until_ms"))
+                return json_error(400, "until_ms required");
 
             std::string actorIdStr = json["actor_id"].s();
             auto        actor      = ActorId::create(actorIdStr);
-            if (!actor.has_value()) return json_error(400, "invalid actor_id");
-            if (!node->actor_index()->exists(actor.value())) return json_error(404, "actor not found");
+            if (!actor.has_value())
+                return json_error(400, "invalid actor_id");
+            if (!node->actor_index()->exists(actor.value()))
+                return json_error(404, "actor not found");
 
             std::uint64_t until_ms = json["until_ms"].u();
-            auto now_ms = static_cast<std::uint64_t>(
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count());
-            if (until_ms <= now_ms) return json_error(400, "until_ms must be in the future");
+            auto now_ms = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                         std::chrono::system_clock::now().time_since_epoch())
+                                                         .count());
+            if (until_ms <= now_ms)
+                return json_error(400, "until_ms must be in the future");
 
             SubscriptionRecord rec;
             rec.until_ms = until_ms;
-            if (json.has("plan")) rec.plan = static_cast<int>(json["plan"].i());
+            if (json.has("plan"))
+                rec.plan = static_cast<int>(json["plan"].i());
 
             auto owner_opt = load_mint_actor();
-            if (!owner_opt.has_value()) return json_error(500, "failed to load owner actor");
+            if (!owner_opt.has_value())
+                return json_error(500, "failed to load owner actor");
             auto owner_actor = owner_opt.value();
 
-            auto sub_row = Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(
-                node->dfs()->get_db_instance(), owner_actor.id(),
-                Dfs::Basic::TEMPLATE_DICTIONARY, "SubscriptionsPay");
-            if (!sub_row.has_value()) return json_error(500, "subscriptions dictionary not found");
+            auto sub_row =
+                Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(node->dfs()->get_db_instance(),
+                                                                                  owner_actor.id(),
+                                                                                  Dfs::Basic::TEMPLATE_DICTIONARY,
+                                                                                  "SubscriptionsPay");
+            if (!sub_row.has_value())
+                return json_error(500, "subscriptions dictionary not found");
 
             std::lock_guard<std::mutex> lock(subscription_mutex);
 
-            node->dfs()->dictionary_set_value(owner_actor.id(), sub_row->file_id, actorIdStr,
-                                              subscription_to_json(rec), owner_actor.id());
+            node->dfs()->dictionary_set_value(owner_actor.id(),
+                                              sub_row->file_id,
+                                              actorIdStr,
+                                              subscription_to_json(rec),
+                                              owner_actor.id());
 
             eLog("[api] [POST] [subscription_add] [actor: {}] [until: {}] [plan: {}]",
-                 actorIdStr, until_ms, rec.plan);
+                 actorIdStr,
+                 until_ms,
+                 rec.plan);
 
             crow::json::wvalue response;
             response["actor_id"] = actorIdStr;
             response["until_ms"] = until_ms;
-            if (rec.plan != 0) response["plan"] = rec.plan;
+            if (rec.plan != 0)
+                response["plan"] = rec.plan;
             return crow::response(200, response);
         } catch (const std::exception& e) {
             return json_error(500, fmt::format("internal error: {}", e.what()));
@@ -672,32 +998,40 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
 
     CROW_ROUTE(app, "/subscription_check").methods("GET"_method)([&](const crow::request& req) -> crow::response {
         try {
-            if (auto err = check_token_get(req)) return std::move(*err);
+            if (auto err = check_token_get(req))
+                return std::move(*err);
 
             auto id = req.url_params.get("actor_id");
-            if (!id) return json_error(400, "actor_id required");
+            if (!id)
+                return json_error(400, "actor_id required");
 
             auto actor = ActorId::create(id);
-            if (!actor.has_value()) return json_error(400, "invalid actor_id");
+            if (!actor.has_value())
+                return json_error(400, "invalid actor_id");
 
             auto owner_opt = load_mint_actor();
-            if (!owner_opt.has_value()) return json_error(500, "failed to load owner actor");
+            if (!owner_opt.has_value())
+                return json_error(500, "failed to load owner actor");
             auto owner_actor = owner_opt.value();
 
-            auto sub_row = Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(
-                node->dfs()->get_db_instance(), owner_actor.id(),
-                Dfs::Basic::TEMPLATE_DICTIONARY, "SubscriptionsPay");
-            if (!sub_row.has_value()) return json_error(500, "subscriptions dictionary not found");
+            auto sub_row =
+                Dfs::Tables::DirsFile::ActorSpace::search_file_by_folder_and_name(node->dfs()->get_db_instance(),
+                                                                                  owner_actor.id(),
+                                                                                  Dfs::Basic::TEMPLATE_DICTIONARY,
+                                                                                  "SubscriptionsPay");
+            if (!sub_row.has_value())
+                return json_error(500, "subscriptions dictionary not found");
 
             auto value = node->dfs()->read_dictionary(owner_actor.id(), sub_row->file_id, actor->to_string());
 
             SubscriptionRecord rec;
-            if (value.has_value()) rec = subscription_from_value(*value);
+            if (value.has_value())
+                rec = subscription_from_value(*value);
             std::uint64_t until_ms = rec.until_ms;
 
-            auto now_ms = static_cast<std::uint64_t>(
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()).count());
+            auto now_ms = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                         std::chrono::system_clock::now().time_since_epoch())
+                                                         .count());
 
             eLog("[api] [GET] [subscription_check] [actor: {}]", actor->to_string());
 
@@ -706,7 +1040,8 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
             response["until_ms"]     = until_ms;
             response["active"]       = until_ms > now_ms;
             response["remaining_ms"] = until_ms > now_ms ? until_ms - now_ms : 0;
-            if (rec.plan != 0) response["plan"] = rec.plan;
+            if (rec.plan != 0)
+                response["plan"] = rec.plan;
             return crow::response(200, response);
         } catch (const std::exception& e) {
             return json_error(500, fmt::format("internal error: {}", e.what()));

--- a/sources/console/console_api.cpp
+++ b/sources/console/console_api.cpp
@@ -106,10 +106,9 @@ namespace {
                 const auto* hash          = proof.if_contains("transaction_hash");
                 const auto* section       = proof.if_contains("section");
                 const auto* confirmations = proof.if_contains("minimum_confirmations");
-                const auto section_value = unsigned_value(section);
-                const auto confirmation_value = confirmations == nullptr
-                                                    ? std::optional<std::uint64_t>(1)
-                                                    : unsigned_value(confirmations);
+                const auto  section_value = unsigned_value(section);
+                const auto  confirmation_value =
+                    confirmations == nullptr ? std::optional<std::uint64_t>(1) : unsigned_value(confirmations);
                 if (hash == nullptr || !hash->is_string() || !section_value.has_value()
                     || !confirmation_value.has_value())
                     return std::unexpected("a DAG proof has invalid fields");
@@ -129,10 +128,10 @@ namespace {
             for (const auto& value : dfs->as_array()) {
                 if (!value.is_object())
                     return std::unexpected("each DFS proof must be an object");
-                const auto& proof   = value.as_object();
-                const auto* owner   = proof.if_contains("owner_id");
-                const auto* file    = proof.if_contains("file_id");
-                const auto* hash    = proof.if_contains("content_hash");
+                const auto& proof = value.as_object();
+                const auto* owner = proof.if_contains("owner_id");
+                const auto* file  = proof.if_contains("file_id");
+                const auto* hash  = proof.if_contains("content_hash");
                 if (owner == nullptr || !owner->is_string() || file == nullptr || !file->is_string()
                     || (hash != nullptr && !hash->is_string()))
                     return std::unexpected("a DFS proof has invalid fields");
@@ -203,7 +202,7 @@ long long parseTimeToMs(const std::string& time_str) {
     return totalMs > 0 ? totalMs : 24 * 60 * 60 * 1000;
 }
 
-void run_api(ExtraChainNode* node, const std::string& api_token) {
+void run_api(ExtraChainNode* node, const std::string& api_token, std::uint16_t port) {
     crow::SimpleApp app;
     std::string     token_session = api_token;
     eLog("API runned.");
@@ -247,6 +246,19 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
             return json_error(400, "token is not valid");
         return std::nullopt;
     };
+
+    CROW_ROUTE(app, "/profile/current").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        const auto wallet = node->account_controller()->current_wallet();
+        if (wallet.empty())
+            return json_error(409, "current wallet is not available");
+        crow::json::wvalue response;
+        response["wallet_id"]  = wallet.id().to_string();
+        response["system_id"]  = node->account_controller()->system_actor().id().to_string();
+        response["network_id"] = node->network_id().to_string();
+        return crow::response(200, response);
+    });
 
     CROW_ROUTE(app, "/contract/list").methods("GET"_method)([&](const crow::request& req) {
         if (auto err = check_token_get(req))
@@ -322,6 +334,43 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         return crow::response(202, response);
     });
 
+    CROW_ROUTE(app, "/token/legacy").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        auto response = crow::response(200, Json::serialize(node->token_manager()->legacy_tokens()));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/token/list").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        auto response = crow::response(200, Json::serialize(node->token_manager()->list_tokens()));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/token/migrate").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* value = object->if_contains("token_id");
+        if (value == nullptr || !value->is_string())
+            return json_error(400, "token_id required");
+        auto token_id = TokenId::create(std::string(value->as_string()));
+        if (!token_id.has_value() || token_id->is_zero())
+            return json_error(400, "invalid token_id");
+        auto migrated = node->token_manager()->migrate_legacy_token(*token_id);
+        if (!migrated.has_value())
+            return json_error(409, "token migration was rejected");
+        auto response = crow::response(202, Json::serialize(migrated.value()));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
     CROW_ROUTE(app, "/toolchain/status").methods("GET"_method)([&](const crow::request& req) {
         if (auto err = check_token_get(req))
             return std::move(*err);
@@ -385,7 +434,7 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         const auto root =
             QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
         const ExtraChain::Contracts::ToolchainInstaller installer(node, root);
-        const auto components = installer.component_catalog();
+        const auto                                      components = installer.component_catalog();
         if (components.empty())
             return json_error(409, "contract toolchain is not installed or its catalog is invalid");
         auto response = crow::response(200, Json::serialize(components));
@@ -415,9 +464,8 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         const auto root =
             QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
         const ExtraChain::Contracts::ToolchainInstaller installer(node, root);
-        const auto result = installer.compose_contract(
-            selected,
-            QString::fromStdString(std::string(project_name->as_string())));
+        const auto                                      result =
+            installer.compose_contract(selected, QString::fromStdString(std::string(project_name->as_string())));
         if (!result.has_value())
             return json_error(409, result.error().detail);
         boost::json::object body;
@@ -527,8 +575,8 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         auto verified = contract_verified_inputs(*object);
         if (!verified.has_value())
             return json_error(400, verified.error());
-        auto transaction = node->submit_contract_call(
-            *contract_id, std::string(json["method"].s()), *arguments, *verified);
+        auto transaction =
+            node->submit_contract_call(*contract_id, std::string(json["method"].s()), *arguments, *verified);
         if (!transaction.has_value())
             return json_error(409, transaction.error().detail);
 
@@ -632,9 +680,58 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         return crow::response(202, response);
     });
 
+    CROW_ROUTE(app, "/transaction/send").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* receiver_value = object->if_contains("receiver");
+        const auto* amount_value   = object->if_contains("amount");
+        if (receiver_value == nullptr || !receiver_value->is_string() || amount_value == nullptr
+            || !amount_value->is_string()) {
+            return json_error(400, "receiver and amount required");
+        }
+        auto receiver = ActorId::create(std::string(receiver_value->as_string()));
+        auto amount   = BigNumberFloat::create(std::string(amount_value->as_string()));
+        if (!receiver.has_value() || receiver.value().is_zero() || !amount.has_value() || amount.value() <= 0)
+            return json_error(400, "invalid receiver or amount");
+
+        TokenId token_id;
+        if (const auto* token_value = object->if_contains("token_id"); token_value != nullptr) {
+            if (!token_value->is_string())
+                return json_error(400, "invalid token_id");
+            const auto token_id_text = std::string(token_value->as_string());
+            if (!token_id_text.empty()) {
+                auto parsed = TokenId::create(token_id_text);
+                if (!parsed.has_value())
+                    return json_error(400, "invalid token_id");
+                token_id = parsed.value();
+            }
+        }
+        const auto contract_token = node->token_manager()->is_contract_token(token_id);
+        auto       transaction    = node->create_transaction(receiver.value(), amount.value(), token_id);
+        if (!transaction.has_value())
+            return json_error(409, "transaction was rejected");
+        if (!contract_token) {
+            auto sent = node->send_transaction(transaction.value(), node->account_controller()->current_wallet());
+            if (!sent.has_value())
+                return json_error(409, "transaction was not submitted");
+            transaction = std::move(sent);
+        }
+        crow::json::wvalue response;
+        response["hash"]     = transaction.value().hash();
+        response["receiver"] = transaction.value().receiver().to_string();
+        response["token_id"] = token_id.to_string();
+        response["type"]     = Utils::enum_value_name_value(transaction.value().type());
+        return crow::response(202, response);
+    });
+
     CROW_ROUTE(app, "/balance").methods("POST"_method)([&](const crow::request& req) {
-        auto json = crow::json::load(req.body);
-        if (!json)
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
             return json_error(400, "invalid json");
         if (auto err = check_token_post(json))
             return std::move(*err);
@@ -646,7 +743,23 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         if (!actor_id.has_value())
             return json_error(400, "invalid actor_id");
 
-        TokenId tokenId("468faf2f1be6504a9a26f7f027f7e43380b0d77d");
+        TokenId token_id;
+        if (const auto* token_value = object->if_contains("token_id"); token_value != nullptr) {
+            if (!token_value->is_string())
+                return json_error(400, "invalid token_id");
+            const auto token_id_text = std::string(token_value->as_string());
+            if (!token_id_text.empty()) {
+                auto parsed = TokenId::create(token_id_text);
+                if (!parsed.has_value())
+                    return json_error(400, "invalid token_id");
+                token_id = parsed.value();
+            }
+        } else {
+            auto rocc = TokenId::create("468faf2f1be6504a9a26f7f027f7e43380b0d77d");
+            if (!rocc.has_value())
+                return json_error(500, "ROCC token identifier is invalid");
+            token_id = rocc.value();
+        }
 
         if (!node->actor_index()->exists(actor_id.value()))
             return json_error(404, "actor not found");
@@ -657,7 +770,7 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
             node->dag()->calculate_actors_balance({ actor_id.value() });
 
         BigNumberFloat balance    = BigNumberFloat(0);
-        auto           balanceKey = std::make_pair(actor_id.value(), tokenId);
+        auto           balanceKey = std::make_pair(actor_id.value(), token_id);
         auto           it         = balances.find(balanceKey);
         if (it != balances.end()) {
             balance = it->second;
@@ -666,6 +779,7 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         crow::json::wvalue response;
         response["actor_id"] = actor_id.value().to_string();
         response["balance"]  = balance.to_string();
+        response["token_id"] = token_id.to_string();
         return crow::response(200, response);
     });
 
@@ -1172,7 +1286,6 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         }
     });
 
-    std::uint16_t port = 17581;
     app.bindaddr("0.0.0.0").port(port).concurrency(2).run();
     eLog("Started api on port {}", port);
 }

--- a/sources/console/console_api.cpp
+++ b/sources/console/console_api.cpp
@@ -26,6 +26,7 @@
 #include <QFile>
 
 #include "managers/extrachain_node.h"
+#include "contracts/contract_manager.h"
 #include "chain/dag.h"
 #include "dfs/dfs_controller.h"
 #include "utils/exc_utils.h"
@@ -132,6 +133,141 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         if (token != token_session) return json_error(400, "token is not valid");
         return std::nullopt;
     };
+
+    CROW_ROUTE(app, "/contract/deploy").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("kind") || !json.has("module_base64")) {
+            return json_error(400, "kind and module_base64 required");
+        }
+        auto module    = Utils::from_base64<std::vector<std::uint8_t>>(std::string(json["module_base64"].s()));
+        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
+            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        if (!module.has_value() || module->empty() || !arguments.has_value()) {
+            return json_error(400, "invalid module or arguments");
+        }
+        auto transaction = node->submit_contract_deploy(std::string(json["kind"].s()), *module, *arguments);
+        if (!transaction.has_value())
+            return json_error(409, transaction.error().detail);
+
+        crow::json::wvalue response;
+        response["contract_id"]      = transaction->receiver().to_string();
+        response["transaction_hash"] = transaction->hash();
+        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        return crow::response(202, response);
+    });
+
+    CROW_ROUTE(app, "/contract/call").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("contract_id") || !json.has("method")) {
+            return json_error(400, "contract_id and method required");
+        }
+        auto contract_id = ActorId::create(std::string(json["contract_id"].s()));
+        if (!contract_id.has_value())
+            return json_error(400, "invalid contract_id");
+        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
+            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        if (!arguments.has_value())
+            return json_error(400, "invalid arguments_base64");
+        auto transaction = node->submit_contract_call(*contract_id, std::string(json["method"].s()), *arguments);
+        if (!transaction.has_value())
+            return json_error(409, transaction.error().detail);
+
+        crow::json::wvalue response;
+        response["transaction_hash"] = transaction->hash();
+        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        return crow::response(202, response);
+    });
+
+    CROW_ROUTE(app, "/contract/query").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("contract_id") || !json.has("method")) {
+            return json_error(400, "contract_id and method required");
+        }
+        auto contract_id = ActorId::create(std::string(json["contract_id"].s()));
+        if (!contract_id.has_value())
+            return json_error(400, "invalid contract_id");
+        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
+            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        if (!arguments.has_value())
+            return json_error(400, "invalid arguments_base64");
+        auto receipt = node->query_contract(*contract_id, std::string(json["method"].s()), *arguments);
+        if (!receipt.has_value())
+            return json_error(409, receipt.error().detail);
+
+        crow::json::wvalue response;
+        response["data_base64"] = Utils::to_base64(receipt->data);
+        response["state_hash"]  = receipt->state_hash;
+        response["version"]     = receipt->version;
+        response["revision"]    = receipt->revision;
+        return crow::response(200, response);
+    });
+
+    CROW_ROUTE(app, "/contract/inspect").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        auto contract_id_raw = req.url_params.get("contract_id");
+        if (!contract_id_raw)
+            return json_error(400, "contract_id required");
+        auto contract_id = ActorId::create(std::string(contract_id_raw));
+        if (!contract_id.has_value())
+            return json_error(400, "invalid contract_id");
+        auto record = node->contract_manager()->inspect(contract_id->to_string());
+        if (!record.has_value())
+            return json_error(404, record.error().detail);
+        const auto& version  = record->versions.at(record->active_version - 1);
+        const auto& revision = version.revisions.back();
+
+        crow::json::wvalue response;
+        response["contract_id"]      = record->contract_id;
+        response["owner_id"]         = record->owner_id;
+        response["kind"]             = record->kind;
+        response["version"]          = version.version;
+        response["revision"]         = revision.revision;
+        response["module_hash"]      = version.module_hash;
+        response["state_hash"]       = revision.state_hash;
+        response["transaction_hash"] = revision.transaction_hash;
+        return crow::response(200, response);
+    });
+
+    CROW_ROUTE(app, "/contract/upgrade").methods("POST"_method)([&](const crow::request& req) {
+        auto json = crow::json::load(req.body);
+        if (!json)
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        if (!json.has("contract_id") || !json.has("module_base64")) {
+            return json_error(400, "contract_id and module_base64 required");
+        }
+        auto contract_id = ActorId::create(std::string(json["contract_id"].s()));
+        if (!contract_id.has_value())
+            return json_error(400, "invalid contract_id");
+        auto module    = Utils::from_base64<std::vector<std::uint8_t>>(std::string(json["module_base64"].s()));
+        auto arguments = Utils::from_base64<std::vector<std::uint8_t>>(
+            json.has("arguments_base64") ? std::string(json["arguments_base64"].s()) : std::string());
+        if (!module.has_value() || module->empty() || !arguments.has_value()) {
+            return json_error(400, "invalid module or arguments");
+        }
+        auto transaction = node->submit_contract_upgrade(*contract_id, *module, *arguments);
+        if (!transaction.has_value())
+            return json_error(409, transaction.error().detail);
+
+        crow::json::wvalue response;
+        response["transaction_hash"] = transaction->hash();
+        response["section"]          = transaction->section().to_string(NumeralBase::Dec);
+        return crow::response(202, response);
+    });
 
     CROW_ROUTE(app, "/balance").methods("POST"_method)([&](const crow::request& req) {
         auto json = crow::json::load(req.body);

--- a/sources/console/console_api.cpp
+++ b/sources/console/console_api.cpp
@@ -471,14 +471,19 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         const auto& revision = version.revisions.back();
 
         crow::json::wvalue response;
-        response["contract_id"]      = record->contract_id;
-        response["owner_id"]         = record->owner_id;
-        response["kind"]             = record->kind;
-        response["version"]          = version.version;
-        response["revision"]         = revision.revision;
-        response["module_hash"]      = version.module_hash;
-        response["state_hash"]       = revision.state_hash;
-        response["transaction_hash"] = revision.transaction_hash;
+        response["contract_id"]                 = record->contract_id;
+        response["owner_id"]                    = record->owner_id;
+        response["kind"]                        = record->kind;
+        response["version"]                     = version.version;
+        response["revision"]                    = revision.revision;
+        response["module_hash"]                 = version.module_hash;
+        response["state_hash"]                  = revision.state_hash;
+        response["transaction_hash"]            = revision.transaction_hash;
+        response["checkpoint_revision"]         = revision.checkpoint_revision;
+        response["checkpoint_section"]          = revision.checkpoint_block;
+        response["checkpoint_state_hash"]       = revision.checkpoint_hash;
+        response["checkpoint_transaction_hash"] = revision.checkpoint_transaction_hash;
+        response["replay_depth"]                = revision.revision - revision.checkpoint_revision;
         return crow::response(200, response);
     });
 

--- a/sources/console/console_api.cpp
+++ b/sources/console/console_api.cpp
@@ -81,6 +81,71 @@ namespace {
         return std::nullopt;
     }
 
+    std::expected<ExtraChain::Contracts::VerifiedInputs, std::string> contract_verified_inputs(
+        const boost::json::object& json) {
+        ExtraChain::Contracts::VerifiedInputs result;
+        const auto unsigned_value = [](const boost::json::value* value) -> std::optional<std::uint64_t> {
+            if (value == nullptr)
+                return std::nullopt;
+            if (value->is_uint64())
+                return value->as_uint64();
+            if (value->is_int64() && value->as_int64() >= 0)
+                return static_cast<std::uint64_t>(value->as_int64());
+            return std::nullopt;
+        };
+        const auto* dag = json.if_contains("dag_proofs");
+        if (dag != nullptr) {
+            if (!dag->is_array())
+                return std::unexpected("dag_proofs must be an array");
+            if (dag->as_array().size() > ExtraChain::Contracts::ContractMaximumProofs)
+                return std::unexpected("too many contract proofs");
+            for (const auto& value : dag->as_array()) {
+                if (!value.is_object())
+                    return std::unexpected("each DAG proof must be an object");
+                const auto& proof         = value.as_object();
+                const auto* hash          = proof.if_contains("transaction_hash");
+                const auto* section       = proof.if_contains("section");
+                const auto* confirmations = proof.if_contains("minimum_confirmations");
+                const auto section_value = unsigned_value(section);
+                const auto confirmation_value = confirmations == nullptr
+                                                    ? std::optional<std::uint64_t>(1)
+                                                    : unsigned_value(confirmations);
+                if (hash == nullptr || !hash->is_string() || !section_value.has_value()
+                    || !confirmation_value.has_value())
+                    return std::unexpected("a DAG proof has invalid fields");
+                result.dag.push_back(ExtraChain::Contracts::DagProof {
+                    .transaction_hash = std::string(hash->as_string()),
+                    .section          = *section_value,
+                    .confirmations    = *confirmation_value,
+                });
+            }
+        }
+        const auto* dfs = json.if_contains("dfs_proofs");
+        if (dfs != nullptr) {
+            if (!dfs->is_array())
+                return std::unexpected("dfs_proofs must be an array");
+            if (result.dag.size() + dfs->as_array().size() > ExtraChain::Contracts::ContractMaximumProofs)
+                return std::unexpected("too many contract proofs");
+            for (const auto& value : dfs->as_array()) {
+                if (!value.is_object())
+                    return std::unexpected("each DFS proof must be an object");
+                const auto& proof   = value.as_object();
+                const auto* owner   = proof.if_contains("owner_id");
+                const auto* file    = proof.if_contains("file_id");
+                const auto* hash    = proof.if_contains("content_hash");
+                if (owner == nullptr || !owner->is_string() || file == nullptr || !file->is_string()
+                    || (hash != nullptr && !hash->is_string()))
+                    return std::unexpected("a DFS proof has invalid fields");
+                result.dfs.push_back(ExtraChain::Contracts::DfsProof {
+                    .file_id      = std::string(file->as_string()),
+                    .owner_id     = std::string(owner->as_string()),
+                    .content_hash = hash == nullptr ? std::string() : std::string(hash->as_string()),
+                });
+            }
+        }
+        return result;
+    }
+
     std::string subscription_to_json(const SubscriptionRecord& rec) {
         return Json::serialize(rec);
     }
@@ -314,6 +379,54 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         return response;
     });
 
+    CROW_ROUTE(app, "/contract/components").methods("GET"_method)([&](const crow::request& req) {
+        if (auto err = check_token_get(req))
+            return std::move(*err);
+        const auto root =
+            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+        const ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+        const auto components = installer.component_catalog();
+        if (components.empty())
+            return json_error(409, "contract toolchain is not installed or its catalog is invalid");
+        auto response = crow::response(200, Json::serialize(components));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
+    CROW_ROUTE(app, "/contract/compose").methods("POST"_method)([&](const crow::request& req) {
+        auto json   = crow::json::load(req.body);
+        auto object = request_object(req);
+        if (!json || !object.has_value())
+            return json_error(400, "invalid json");
+        if (auto err = check_token_post(json))
+            return std::move(*err);
+        const auto* project_name = object->if_contains("project_name");
+        const auto* components   = object->if_contains("components");
+        if (project_name == nullptr || !project_name->is_string() || components == nullptr
+            || !components->is_array() || components->as_array().empty())
+            return json_error(400, "project_name and components required");
+        std::vector<std::string> selected;
+        selected.reserve(components->as_array().size());
+        for (const auto& component : components->as_array()) {
+            if (!component.is_string() || component.as_string().empty())
+                return json_error(400, "each component must be a non-empty string");
+            selected.emplace_back(component.as_string());
+        }
+        const auto root =
+            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/contract-toolchain";
+        const ExtraChain::Contracts::ToolchainInstaller installer(node, root);
+        const auto result = installer.compose_contract(
+            selected,
+            QString::fromStdString(std::string(project_name->as_string())));
+        if (!result.has_value())
+            return json_error(409, result.error().detail);
+        boost::json::object body;
+        body["source"] = result->toStdString();
+        auto response  = crow::response(200, boost::json::serialize(body));
+        response.set_header("Content-Type", "application/json");
+        return response;
+    });
+
     CROW_ROUTE(app, "/toolchain/publish-package").methods("POST"_method)([&](const crow::request& req) {
         auto json   = crow::json::load(req.body);
         auto object = request_object(req);
@@ -411,7 +524,11 @@ void run_api(ExtraChainNode* node, const std::string& api_token) {
         auto arguments = contract_arguments(*object);
         if (!arguments.has_value())
             return json_error(400, arguments.error());
-        auto transaction = node->submit_contract_call(*contract_id, std::string(json["method"].s()), *arguments);
+        auto verified = contract_verified_inputs(*object);
+        if (!verified.has_value())
+            return json_error(400, verified.error());
+        auto transaction = node->submit_contract_call(
+            *contract_id, std::string(json["method"].s()), *arguments, *verified);
         if (!transaction.has_value())
             return json_error(409, transaction.error().detail);
 

--- a/sources/console/console_manager.cpp
+++ b/sources/console/console_manager.cpp
@@ -179,7 +179,7 @@ void ConsoleManager::commandReceiver(QString command) {
 
     if (command.left(7) == "connect") {
         auto list = command.split(" ");
-        if (list.length() != 3)
+        if (list.length() != 3 && list.length() != 4)
             return;
 
         QString ip = list[2];
@@ -189,8 +189,24 @@ void ConsoleManager::commandReceiver(QString command) {
 
         if (Utils::isValidIp(ip) && (protocol == "udp" || protocol == "ws")) {
             auto networkProtocol = Network::Protocol::WebSocket;
-            qInfo().noquote() << "Connect to" << ip << protocol;
-            node->network()->connect_to_node(ip, networkProtocol);
+            if (list.length() == 4) {
+                bool          port_ok = false;
+                const quint16 port    = list[3].toUShort(&port_ok);
+                if (!port_ok || port == 0 || protocol != "ws") {
+                    eInfo("Invalid connect port");
+                    return;
+                }
+                qInfo().noquote() << "Connect to" << ip << protocol << port;
+                QMetaObject::invokeMethod(
+                    node->network(),
+                    [network = node->network(), ip, port]() {
+                        network->connect_to_endpoint(ip, port);
+                    },
+                    Qt::QueuedConnection);
+            } else {
+                qInfo().noquote() << "Connect to" << ip << protocol;
+                node->network()->connect_to_node(ip, networkProtocol);
+            }
         } else {
             eInfo("Invalid connect input");
         }
@@ -280,7 +296,6 @@ void ConsoleManager::commandReceiver(QString command) {
             eInfo("Can't export, error: {}", exported.error());
             return;
         }
-        auto    data = QString::fromStdString(exported.value());
         QString fileName =
             QString("%1.extrachain").arg(node->account_controller()->system_actor().id().toQString());
         QFile file(fileName);
@@ -288,8 +303,11 @@ void ConsoleManager::commandReceiver(QString command) {
             eInfo("Can't open {} for writing: {}", fileName, file.errorString());
             return;
         }
-        if (file.write(data.toUtf8()) > 1)
+        const QByteArray data = QByteArray::fromStdString(*exported);
+        if (file.write(data) == data.size())
             eInfo("Exported to {}", fileName);
+        else
+            eInfo("Can't write complete profile export to {}: {}", fileName, file.errorString());
         file.close();
     }
 

--- a/sources/console/console_manager.cpp
+++ b/sources/console/console_manager.cpp
@@ -132,7 +132,7 @@ void ConsoleManager::commandReceiver(QString command) {
         if (sendtx.length() == 3) {
             QByteArray     toId   = sendtx[1].toUtf8();
             BigNumberFloat amount = BigNumberFloat(sendtx[2].toStdString());
-            eLog("transaction {} {}", toId, amount.to_string(NumeralBase::Dec));
+            eLog("transaction {} {}", toId, amount.to_string());
 
             ActorId receiver(toId.toStdString());
 
@@ -146,7 +146,10 @@ void ConsoleManager::commandReceiver(QString command) {
             tx.set_receiver(receiver);
             tx.set_amount(amount);
             // createTransaction
-            node->send_transaction(tx, node->account_controller()->system_actor());
+            const auto result = node->send_transaction(tx, node->account_controller()->system_actor());
+            if (!result.has_value()) {
+                eInfo("Transaction failed: {}", Utils::enum_value_name_value(result.error()));
+            }
 
             //            if (mainActorId != firstId)
             //            node->createTransaction(receiver, BigNumberFloat(10), ActorId());
@@ -275,12 +278,16 @@ void ConsoleManager::commandReceiver(QString command) {
         auto exported = node->export_profile();
         if (!exported.has_value()) {
             eInfo("Can't export, error: {}", exported.error());
+            return;
         }
         auto    data = QString::fromStdString(exported.value());
         QString fileName =
             QString("%1.extrachain").arg(node->account_controller()->system_actor().id().toQString());
         QFile file(fileName);
-        file.open(QFile::WriteOnly);
+        if (!file.open(QFile::WriteOnly)) {
+            eInfo("Can't open {} for writing: {}", fileName, file.errorString());
+            return;
+        }
         if (file.write(data.toUtf8()) > 1)
             eInfo("Exported to {}", fileName);
         file.close();


### PR DESCRIPTION
Summary:
- add deploy, call, query, inspect, and upgrade HTTP endpoints
- use the existing console token authentication and ExtraChainNode methods
- document the contract API encoding and response rules

Validation:
- console API translation unit compiles against the contract-enabled core
- diff and style review pass